### PR TITLE
Preserve Immich EXIF metadata and gallery sorting

### DIFF
--- a/Models/ImageItem.vb
+++ b/Models/ImageItem.vb
@@ -831,29 +831,46 @@ Namespace Models
             item.Rating = asset.Rating
             item.Tags = If(asset.Tags, New List(Of String)())
             item.ExifDateTaken = asset.ExifDateTaken
+            item.ExifDateModified = asset.ExifDateModified
             item.ExifCamera = asset.Camera
             item.ExifIso = asset.Iso
             item.ExifAperture = asset.Aperture
             Dim created = If(asset.FileCreatedAt.HasValue, asset.FileCreatedAt.Value, DateTime.MinValue)
             item.FileCreatedAt = created
-            item.DateModified = created
+            item.DateModified = If(asset.FileModifiedAt.HasValue, asset.FileModifiedAt.Value, created)
             Return item
         End Function
 
-        ''' <summary>Ergänzt ein Immich-Item um die erst per Detail-Abruf verfügbaren Metadaten
-        ''' (Dateigröße, Rating, Kamera/ISO/Blende, Aufnahmedatum, Stichwörter) und feuert die passenden
-        ''' PropertyChanged, damit Kachel und Info-Leiste sich aktualisieren.</summary>
-        Public Sub ApplyImmichDetail(fileSizeBytes As Long, rating As Integer, camera As String,
-                                     iso As Integer?, aperture As Double?, dateTaken As DateTime?, tags As List(Of String))
-            If Not IsImmichAsset Then Return
-            FileSize = fileSizeBytes
+        ''' <summary>Übernimmt die vollständigen, sortierbaren Metadaten eines Immich-Assets. Derselbe
+        ''' Weg aktualisiert sowohl den sofort angezeigten lokalen Katalog beim Server-Abgleich als auch
+        ''' die später eintreffende Detailantwort eines sichtbaren Elements.</summary>
+        Public Sub ApplyImmichMetadata(asset As ImmichAsset, Optional replaceMissingDates As Boolean = False)
+            If Not IsImmichAsset OrElse asset Is Nothing Then Return
+            FileSize = asset.FileSizeBytes
             RaisePropertyChanged(NameOf(FileSizeText))
-            Me.Rating = rating
-            ExifCamera = camera
-            ExifIso = iso
-            ExifAperture = aperture
-            If dateTaken.HasValue Then ExifDateTaken = dateTaken
-            Me.Tags = If(tags, New List(Of String)())
+            Me.Rating = asset.Rating
+            Me.IsFavorite = asset.IsFavorite
+            ImageWidth = asset.Width
+            ImageHeight = asset.Height
+            ExifCamera = asset.Camera
+            ExifIso = asset.Iso
+            ExifAperture = asset.Aperture
+            If replaceMissingDates OrElse asset.ExifDateTaken.HasValue Then ExifDateTaken = asset.ExifDateTaken
+            If replaceMissingDates OrElse asset.ExifDateModified.HasValue Then ExifDateModified = asset.ExifDateModified
+            If asset.FileCreatedAt.HasValue Then
+                FileCreatedAt = asset.FileCreatedAt.Value
+            ElseIf replaceMissingDates Then
+                FileCreatedAt = DateTime.MinValue
+            End If
+            If asset.FileModifiedAt.HasValue Then
+                DateModified = asset.FileModifiedAt.Value
+            ElseIf asset.FileCreatedAt.HasValue Then
+                DateModified = asset.FileCreatedAt.Value
+            ElseIf replaceMissingDates Then
+                DateModified = DateTime.MinValue
+            End If
+            RaisePropertyChanged(NameOf(DateText))
+            Me.Tags = If(asset.Tags, New List(Of String)())
             RaisePropertyChanged(NameOf(Tags))
             RaisePropertyChanged(NameOf(SearchText))
         End Sub
@@ -1275,8 +1292,7 @@ Namespace Models
                                            Dim detail = Await ImmichService.GetAssetDetailCachedAsync(assetId, updatedAt, token).ConfigureAwait(False)
                                            If detail Is Nothing OrElse token.IsCancellationRequested Then Return
                                            Await Dispatcher.UIThread.InvokeAsync(
-                                               Sub() ApplyImmichDetail(detail.FileSizeBytes, detail.Rating, detail.Camera,
-                                                                       detail.Iso, detail.Aperture, detail.ExifDateTaken, detail.Tags))
+                                               Sub() ApplyImmichMetadata(detail))
                                        Catch
                                        End Try
                                    End Function)

--- a/Services/ImmichIndexService.vb
+++ b/Services/ImmichIndexService.vb
@@ -28,10 +28,12 @@ Namespace Services
             End Get
         End Property
 
-        Private Sub New()
-            Dim dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "FerrumPix")
+        Private Sub New(Optional databasePath As String = Nothing)
+            Dim dir = If(String.IsNullOrWhiteSpace(databasePath),
+                         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "FerrumPix"),
+                         Path.GetDirectoryName(databasePath))
             Directory.CreateDirectory(dir)
-            _dbPath = Path.Combine(dir, "immich-index.db")
+            _dbPath = If(String.IsNullOrWhiteSpace(databasePath), Path.Combine(dir, "immich-index.db"), databasePath)
             _connectionString = $"Data Source={_dbPath}"
             Try
                 InitDb()
@@ -39,6 +41,12 @@ Namespace Services
                 DiagnosticLogService.LogException("ImmichIndex.Init", ex)
             End Try
         End Sub
+
+        ''' <summary>Erzeugt einen isolierten Index für die Vertragsregressionen, ohne den
+        ''' Anwendungskatalog des Benutzers zu berühren.</summary>
+        Private Shared Function CreateForDiagnostics(databasePath As String) As ImmichIndexService
+            Return New ImmichIndexService(databasePath)
+        End Function
 
         Private Sub InitDb()
             Using conn = New SqliteConnection(_connectionString)
@@ -58,7 +66,10 @@ Namespace Services
                         "  Camera     TEXT," &
                         "  Iso        INTEGER," &
                         "  Aperture   REAL," &
+                        "  FileCreatedAt TEXT," &
+                        "  FileModifiedAt TEXT," &
                         "  DateTaken  TEXT," &
+                        "  DateModified TEXT," &
                         "  Tags       TEXT NOT NULL DEFAULT ''," &
                         "  Width      INTEGER NOT NULL DEFAULT 0," &
                         "  Height     INTEGER NOT NULL DEFAULT 0," &
@@ -79,6 +90,10 @@ Namespace Services
                         "  FileName      TEXT NOT NULL DEFAULT ''," &
                         "  IsVideo       INTEGER NOT NULL DEFAULT 0," &
                         "  FileCreatedAt TEXT," &
+                        "  FileModifiedAt TEXT," &
+                        "  FileSize      INTEGER NOT NULL DEFAULT 0," &
+                        "  DateTaken     TEXT," &
+                        "  DateModified  TEXT," &
                         "  Width         INTEGER NOT NULL DEFAULT 0," &
                         "  Height        INTEGER NOT NULL DEFAULT 0," &
                         "  IsFavorite    INTEGER NOT NULL DEFAULT 0," &
@@ -87,6 +102,29 @@ Namespace Services
                         ")"
                     cmd.ExecuteNonQuery()
                 End Using
+                EnsureColumn(conn, "AssetMeta", "FileCreatedAt", "TEXT")
+                EnsureColumn(conn, "AssetMeta", "FileModifiedAt", "TEXT")
+                EnsureColumn(conn, "AssetMeta", "DateModified", "TEXT")
+                EnsureColumn(conn, "AssetList", "FileModifiedAt", "TEXT")
+                EnsureColumn(conn, "AssetList", "FileSize", "INTEGER NOT NULL DEFAULT 0")
+                EnsureColumn(conn, "AssetList", "DateTaken", "TEXT")
+                EnsureColumn(conn, "AssetList", "DateModified", "TEXT")
+            End Using
+        End Sub
+
+        Private Shared Sub EnsureColumn(conn As SqliteConnection, tableName As String,
+                                        columnName As String, definition As String)
+            Using check = conn.CreateCommand()
+                check.CommandText = $"PRAGMA table_info({tableName})"
+                Using reader = check.ExecuteReader()
+                    While reader.Read()
+                        If String.Equals(reader.GetString(1), columnName, StringComparison.OrdinalIgnoreCase) Then Return
+                    End While
+                End Using
+            End Using
+            Using alter = conn.CreateCommand()
+                alter.CommandText = $"ALTER TABLE {tableName} ADD COLUMN {columnName} {definition}"
+                alter.ExecuteNonQuery()
             End Using
         End Sub
 
@@ -99,7 +137,7 @@ Namespace Services
                 Using conn = New SqliteConnection(_connectionString)
                     conn.Open()
                     Using cmd = conn.CreateCommand()
-                        cmd.CommandText = "SELECT AssetId,FileName,IsVideo,FileCreatedAt,Width,Height,IsFavorite,UpdatedAt " &
+                        cmd.CommandText = "SELECT AssetId,FileName,IsVideo,FileCreatedAt,FileModifiedAt,FileSize,DateTaken,DateModified,Width,Height,IsFavorite,UpdatedAt " &
                                           "FROM AssetList WHERE ServerKey=$s ORDER BY Position"
                         cmd.Parameters.AddWithValue("$s", serverKey)
                         Using r = cmd.ExecuteReader()
@@ -109,10 +147,14 @@ Namespace Services
                                     .FileName = If(r.IsDBNull(1), "", r.GetString(1)),
                                     .IsVideo = Not r.IsDBNull(2) AndAlso r.GetInt32(2) <> 0,
                                     .FileCreatedAt = ParseDate(If(r.IsDBNull(3), "", r.GetString(3))),
-                                    .Width = If(r.IsDBNull(4), 0, r.GetInt32(4)),
-                                    .Height = If(r.IsDBNull(5), 0, r.GetInt32(5)),
-                                    .IsFavorite = Not r.IsDBNull(6) AndAlso r.GetInt32(6) <> 0,
-                                    .UpdatedAt = If(r.IsDBNull(7), "", r.GetString(7))
+                                    .FileModifiedAt = ParseDate(If(r.IsDBNull(4), "", r.GetString(4))),
+                                    .FileSizeBytes = If(r.IsDBNull(5), 0L, r.GetInt64(5)),
+                                    .ExifDateTaken = ParseDate(If(r.IsDBNull(6), "", r.GetString(6))),
+                                    .ExifDateModified = ParseDate(If(r.IsDBNull(7), "", r.GetString(7))),
+                                    .Width = If(r.IsDBNull(8), 0, r.GetInt32(8)),
+                                    .Height = If(r.IsDBNull(9), 0, r.GetInt32(9)),
+                                    .IsFavorite = Not r.IsDBNull(10) AndAlso r.GetInt32(10) <> 0,
+                                    .UpdatedAt = If(r.IsDBNull(11), "", r.GetString(11))
                                 })
                             End While
                         End Using
@@ -142,14 +184,18 @@ Namespace Services
                         End Using
                         Using ins = conn.CreateCommand()
                             ins.Transaction = transaction
-                            ins.CommandText = "INSERT INTO AssetList(ServerKey,Position,AssetId,FileName,IsVideo,FileCreatedAt,Width,Height,IsFavorite,UpdatedAt) " &
-                                              "VALUES($s,$pos,$a,$n,$v,$c,$w,$h,$f,$u)"
+                            ins.CommandText = "INSERT INTO AssetList(ServerKey,Position,AssetId,FileName,IsVideo,FileCreatedAt,FileModifiedAt,FileSize,DateTaken,DateModified,Width,Height,IsFavorite,UpdatedAt) " &
+                                              "VALUES($s,$pos,$a,$n,$v,$c,$m,$fs,$dt,$dm,$w,$h,$f,$u)"
                             Dim pS = ins.Parameters.Add("$s", SqliteType.Text)
                             Dim pPos = ins.Parameters.Add("$pos", SqliteType.Integer)
                             Dim pA = ins.Parameters.Add("$a", SqliteType.Text)
                             Dim pN = ins.Parameters.Add("$n", SqliteType.Text)
                             Dim pV = ins.Parameters.Add("$v", SqliteType.Integer)
                             Dim pC = ins.Parameters.Add("$c", SqliteType.Text)
+                            Dim pM = ins.Parameters.Add("$m", SqliteType.Text)
+                            Dim pFs = ins.Parameters.Add("$fs", SqliteType.Integer)
+                            Dim pDt = ins.Parameters.Add("$dt", SqliteType.Text)
+                            Dim pDm = ins.Parameters.Add("$dm", SqliteType.Text)
                             Dim pW = ins.Parameters.Add("$w", SqliteType.Integer)
                             Dim pH = ins.Parameters.Add("$h", SqliteType.Integer)
                             Dim pF = ins.Parameters.Add("$f", SqliteType.Integer)
@@ -163,6 +209,10 @@ Namespace Services
                                 pN.Value = If(a.FileName, "")
                                 pV.Value = If(a.IsVideo, 1, 0)
                                 pC.Value = If(a.FileCreatedAt.HasValue, a.FileCreatedAt.Value.ToString("o", CultureInfo.InvariantCulture), CType(DBNull.Value, Object))
+                                pM.Value = If(a.FileModifiedAt.HasValue, a.FileModifiedAt.Value.ToString("o", CultureInfo.InvariantCulture), CType(DBNull.Value, Object))
+                                pFs.Value = a.FileSizeBytes
+                                pDt.Value = If(a.ExifDateTaken.HasValue, a.ExifDateTaken.Value.ToString("o", CultureInfo.InvariantCulture), CType(DBNull.Value, Object))
+                                pDm.Value = If(a.ExifDateModified.HasValue, a.ExifDateModified.Value.ToString("o", CultureInfo.InvariantCulture), CType(DBNull.Value, Object))
                                 pW.Value = a.Width
                                 pH.Value = a.Height
                                 pF.Value = If(a.IsFavorite, 1, 0)
@@ -186,7 +236,7 @@ Namespace Services
                 Using conn = New SqliteConnection(_connectionString)
                     conn.Open()
                     Using cmd = conn.CreateCommand()
-                        cmd.CommandText = "SELECT UpdatedAt,FileSize,Rating,Camera,Iso,Aperture,DateTaken,Tags,Width,Height,IsFavorite " &
+                        cmd.CommandText = "SELECT UpdatedAt,FileSize,Rating,Camera,Iso,Aperture,FileCreatedAt,FileModifiedAt,DateTaken,DateModified,Tags,Width,Height,IsFavorite " &
                                           "FROM AssetMeta WHERE ServerKey=$s AND AssetId=$a"
                         cmd.Parameters.AddWithValue("$s", serverKey)
                         cmd.Parameters.AddWithValue("$a", assetId)
@@ -204,11 +254,14 @@ Namespace Services
                                 .Camera = If(r.IsDBNull(3), "", r.GetString(3)),
                                 .Iso = If(r.IsDBNull(4), CType(Nothing, Integer?), r.GetInt32(4)),
                                 .Aperture = If(r.IsDBNull(5), CType(Nothing, Double?), r.GetDouble(5)),
-                                .ExifDateTaken = ParseDate(If(r.IsDBNull(6), "", r.GetString(6))),
-                                .Tags = SplitTags(If(r.IsDBNull(7), "", r.GetString(7))),
-                                .Width = If(r.IsDBNull(8), 0, r.GetInt32(8)),
-                                .Height = If(r.IsDBNull(9), 0, r.GetInt32(9)),
-                                .IsFavorite = Not r.IsDBNull(10) AndAlso r.GetInt32(10) <> 0
+                                .FileCreatedAt = ParseDate(If(r.IsDBNull(6), "", r.GetString(6))),
+                                .FileModifiedAt = ParseDate(If(r.IsDBNull(7), "", r.GetString(7))),
+                                .ExifDateTaken = ParseDate(If(r.IsDBNull(8), "", r.GetString(8))),
+                                .ExifDateModified = ParseDate(If(r.IsDBNull(9), "", r.GetString(9))),
+                                .Tags = SplitTags(If(r.IsDBNull(10), "", r.GetString(10))),
+                                .Width = If(r.IsDBNull(11), 0, r.GetInt32(11)),
+                                .Height = If(r.IsDBNull(12), 0, r.GetInt32(12)),
+                                .IsFavorite = Not r.IsDBNull(13) AndAlso r.GetInt32(13) <> 0
                             }
                             Return asset
                         End Using
@@ -228,10 +281,10 @@ Namespace Services
                     conn.Open()
                     Using cmd = conn.CreateCommand()
                         cmd.CommandText =
-                            "INSERT INTO AssetMeta(ServerKey,AssetId,UpdatedAt,FileSize,Rating,Camera,Iso,Aperture,DateTaken,Tags,Width,Height,IsFavorite) " &
-                            "VALUES($s,$a,$u,$fs,$r,$cam,$iso,$ap,$dt,$tags,$w,$h,$fav) " &
+                            "INSERT INTO AssetMeta(ServerKey,AssetId,UpdatedAt,FileSize,Rating,Camera,Iso,Aperture,FileCreatedAt,FileModifiedAt,DateTaken,DateModified,Tags,Width,Height,IsFavorite) " &
+                            "VALUES($s,$a,$u,$fs,$r,$cam,$iso,$ap,$fc,$fm,$dt,$dm,$tags,$w,$h,$fav) " &
                             "ON CONFLICT(ServerKey,AssetId) DO UPDATE SET " &
-                            "UpdatedAt=$u,FileSize=$fs,Rating=$r,Camera=$cam,Iso=$iso,Aperture=$ap,DateTaken=$dt,Tags=$tags,Width=$w,Height=$h,IsFavorite=$fav"
+                            "UpdatedAt=$u,FileSize=$fs,Rating=$r,Camera=$cam,Iso=$iso,Aperture=$ap,FileCreatedAt=$fc,FileModifiedAt=$fm,DateTaken=$dt,DateModified=$dm,Tags=$tags,Width=$w,Height=$h,IsFavorite=$fav"
                         cmd.Parameters.AddWithValue("$s", serverKey)
                         cmd.Parameters.AddWithValue("$a", asset.Id)
                         cmd.Parameters.AddWithValue("$u", If(asset.UpdatedAt, ""))
@@ -240,7 +293,10 @@ Namespace Services
                         cmd.Parameters.AddWithValue("$cam", If(CObj(asset.Camera), DBNull.Value))
                         cmd.Parameters.AddWithValue("$iso", If(asset.Iso.HasValue, CObj(asset.Iso.Value), DBNull.Value))
                         cmd.Parameters.AddWithValue("$ap", If(asset.Aperture.HasValue, CObj(asset.Aperture.Value), DBNull.Value))
+                        cmd.Parameters.AddWithValue("$fc", If(asset.FileCreatedAt.HasValue, CObj(asset.FileCreatedAt.Value.ToString("o", CultureInfo.InvariantCulture)), DBNull.Value))
+                        cmd.Parameters.AddWithValue("$fm", If(asset.FileModifiedAt.HasValue, CObj(asset.FileModifiedAt.Value.ToString("o", CultureInfo.InvariantCulture)), DBNull.Value))
                         cmd.Parameters.AddWithValue("$dt", If(asset.ExifDateTaken.HasValue, CObj(asset.ExifDateTaken.Value.ToString("o", CultureInfo.InvariantCulture)), DBNull.Value))
+                        cmd.Parameters.AddWithValue("$dm", If(asset.ExifDateModified.HasValue, CObj(asset.ExifDateModified.Value.ToString("o", CultureInfo.InvariantCulture)), DBNull.Value))
                         cmd.Parameters.AddWithValue("$tags", JoinTags(asset.Tags))
                         cmd.Parameters.AddWithValue("$w", asset.Width)
                         cmd.Parameters.AddWithValue("$h", asset.Height)

--- a/Services/ImmichIndexService.vb
+++ b/Services/ImmichIndexService.vb
@@ -28,12 +28,10 @@ Namespace Services
             End Get
         End Property
 
-        Private Sub New(Optional databasePath As String = Nothing)
-            Dim dir = If(String.IsNullOrWhiteSpace(databasePath),
-                         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "FerrumPix"),
-                         Path.GetDirectoryName(databasePath))
+        Private Sub New()
+            Dim dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "FerrumPix")
             Directory.CreateDirectory(dir)
-            _dbPath = If(String.IsNullOrWhiteSpace(databasePath), Path.Combine(dir, "immich-index.db"), databasePath)
+            _dbPath = Path.Combine(dir, "immich-index.db")
             _connectionString = $"Data Source={_dbPath}"
             Try
                 InitDb()
@@ -41,12 +39,6 @@ Namespace Services
                 DiagnosticLogService.LogException("ImmichIndex.Init", ex)
             End Try
         End Sub
-
-        ''' <summary>Erzeugt einen isolierten Index für die Vertragsregressionen, ohne den
-        ''' Anwendungskatalog des Benutzers zu berühren.</summary>
-        Private Shared Function CreateForDiagnostics(databasePath As String) As ImmichIndexService
-            Return New ImmichIndexService(databasePath)
-        End Function
 
         Private Sub InitDb()
             Using conn = New SqliteConnection(_connectionString)

--- a/Services/ImmichService.vb
+++ b/Services/ImmichService.vb
@@ -918,26 +918,48 @@ Namespace Services
                 Dim client = GetClient()
                 ' Ein gemeinsamer Fetcher fuer "Alle Fotos", Alben, Personen und Orte - search/metadata
                 ' filtert wahlweise per albumIds, personIds (Gesichtserkennung des Servers) oder city.
-                Dim requestBody = BuildAssetPageSearchBody(page, albumId, personId, city)
+                Dim requestBody = BuildAssetPageSearchBody(page, albumId, personId, city, includeExif:=True)
+                Dim statusCode As Integer
+                Dim body As String
                 Using content = New StringContent(requestBody, Encoding.UTF8, "application/json")
                     Using resp = Await client.PostAsync(ApiUrl("search/metadata"), content, cancellationToken).ConfigureAwait(False)
-                        resp.EnsureSuccessStatusCode()
-                        Dim body = Await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(False)
-                        Dim dto = JsonSerializer.Deserialize(Of ImmichSearchResponseDto)(body, JsonOptions)
-                        Dim items = dto?.Assets?.Items
-                        If items IsNot Nothing Then
-                            For Each a In items
-                                If a Is Nothing OrElse String.IsNullOrEmpty(a.Id) Then Continue For
-                                If Not IsBrowsableAsset(a.Visibility) Then Continue For
-                                result.Items.Add(MapAsset(a))
-                            Next
-                        End If
-                        Dim parsedPage As Integer
-                        If Not String.IsNullOrEmpty(dto?.Assets?.NextPage) AndAlso Integer.TryParse(dto.Assets.NextPage, parsedPage) Then
-                            result.NextPage = parsedPage
-                        End If
+                        statusCode = CInt(resp.StatusCode)
+                        body = Await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(False)
                     End Using
                 End Using
+
+                ' Older Immich servers may reject the optional withExif field instead of ignoring
+                ' it. Retry only for that specific contract error; network failures and invalid
+                ' filters must not cause a second request or hide the original failure.
+                If IsWithExifRejected(statusCode, body) Then
+                    DiagnosticLogService.LogAlways("Immich.GetAssetsPage",
+                                                   $"HTTP {statusCode} für withExif - Wiederholung ohne EXIF")
+                    requestBody = BuildAssetPageSearchBody(page, albumId, personId, city, includeExif:=False)
+                    Using content = New StringContent(requestBody, Encoding.UTF8, "application/json")
+                        Using resp = Await client.PostAsync(ApiUrl("search/metadata"), content, cancellationToken).ConfigureAwait(False)
+                            statusCode = CInt(resp.StatusCode)
+                            body = Await resp.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(False)
+                        End Using
+                    End Using
+                End If
+
+                If statusCode < 200 OrElse statusCode >= 300 Then
+                    Throw New HttpRequestException($"HTTP {statusCode} bei Immich-Metadatensuche")
+                End If
+
+                Dim dto = JsonSerializer.Deserialize(Of ImmichSearchResponseDto)(body, JsonOptions)
+                Dim items = dto?.Assets?.Items
+                If items IsNot Nothing Then
+                    For Each a In items
+                        If a Is Nothing OrElse String.IsNullOrEmpty(a.Id) Then Continue For
+                        If Not IsBrowsableAsset(a.Visibility) Then Continue For
+                        result.Items.Add(MapAsset(a))
+                    Next
+                End If
+                Dim parsedPage As Integer
+                If Not String.IsNullOrEmpty(dto?.Assets?.NextPage) AndAlso Integer.TryParse(dto.Assets.NextPage, parsedPage) Then
+                    result.NextPage = parsedPage
+                End If
                 LastError = Nothing
             Catch ex As OperationCanceledException When cancellationToken.IsCancellationRequested
                 Throw
@@ -951,13 +973,23 @@ Namespace Services
         ''' <summary>Gemeinsamer, rein funktionaler Aufbau des Requests für die Galerie-Timeline.
         ''' Als eigene Naht lässt sich der API-Vertrag ohne einen laufenden Immich-Server prüfen.</summary>
         Private Shared Function BuildAssetPageSearchBody(page As Integer, albumId As String,
-                                                         personId As String, city As String) As String
+                                                         personId As String, city As String,
+                                                         Optional includeExif As Boolean = True) As String
             Dim filters As New List(Of String)()
             If Not String.IsNullOrWhiteSpace(albumId) Then filters.Add($"""albumIds"":[""{albumId}""]")
             If Not String.IsNullOrWhiteSpace(personId) Then filters.Add($"""personIds"":[""{personId}""]")
             If Not String.IsNullOrWhiteSpace(city) Then filters.Add($"""city"":{JsonSerializer.Serialize(city)}")
             Dim filterPrefix = If(filters.Count > 0, String.Join(",", filters) & ",", "")
-            Return $"{{{filterPrefix}""page"":{Math.Max(1, page)},""size"":{AssetPageSize},""withExif"":true}}"
+            Dim exifPart = If(includeExif, ",""withExif"":true", "")
+            Return $"{{{filterPrefix}""page"":{Math.Max(1, page)},""size"":{AssetPageSize}{exifPart}}}"
+        End Function
+
+        Private Shared Function IsWithExifRejected(statusCode As Integer, body As String) As Boolean
+            If statusCode <> 400 AndAlso statusCode <> 422 Then Return False
+            Dim text = If(body, "")
+            Return text.IndexOf("withExif", StringComparison.OrdinalIgnoreCase) >= 0 OrElse
+                   text.IndexOf("unknown property", StringComparison.OrdinalIgnoreCase) >= 0 OrElse
+                   text.IndexOf("not allowed", StringComparison.OrdinalIgnoreCase) >= 0
         End Function
 
         ''' <summary>Benannte Personen der serverseitigen Gesichtserkennung (GET /api/people).
@@ -1096,14 +1128,6 @@ Namespace Services
             End If
             ApplyFerrumPixDescriptionMeta(item)
             Return item
-        End Function
-
-        ''' <summary>Schmale Diagnose-Naht für die JSON-Vertragsregressionen der Immich-Anbindung.
-        ''' Verwendet absichtlich denselben DTO- und Mapping-Pfad wie echte Serverantworten.</summary>
-        Private Shared Function MapAssetJsonForDiagnostics(json As String) As ImmichAsset
-            Dim dto = JsonSerializer.Deserialize(Of ImmichAssetDto)(json, JsonOptions)
-            If dto Is Nothing Then Return Nothing
-            Return MapAsset(dto)
         End Function
 
         Private Const FerrumPixMetaStart As String = "[FerrumPix]"

--- a/Services/ImmichService.vb
+++ b/Services/ImmichService.vb
@@ -30,7 +30,9 @@ Namespace Services
         Public Property FileName As String = ""
         Public Property IsVideo As Boolean
         Public Property FileCreatedAt As DateTime?
+        Public Property FileModifiedAt As DateTime?
         Public Property ExifDateTaken As DateTime?
+        Public Property ExifDateModified As DateTime?
         Public Property Width As Integer
         Public Property Height As Integer
         Public Property Camera As String = ""
@@ -916,12 +918,7 @@ Namespace Services
                 Dim client = GetClient()
                 ' Ein gemeinsamer Fetcher fuer "Alle Fotos", Alben, Personen und Orte - search/metadata
                 ' filtert wahlweise per albumIds, personIds (Gesichtserkennung des Servers) oder city.
-                Dim filters As New List(Of String)()
-                If Not String.IsNullOrWhiteSpace(albumId) Then filters.Add($"""albumIds"":[""{albumId}""]")
-                If Not String.IsNullOrWhiteSpace(personId) Then filters.Add($"""personIds"":[""{personId}""]")
-                If Not String.IsNullOrWhiteSpace(city) Then filters.Add($"""city"":{JsonSerializer.Serialize(city)}")
-                Dim filterPrefix = If(filters.Count > 0, String.Join(",", filters) & ",", "")
-                Dim requestBody = $"{{{filterPrefix}""page"":{Math.Max(1, page)},""size"":{AssetPageSize}}}"
+                Dim requestBody = BuildAssetPageSearchBody(page, albumId, personId, city)
                 Using content = New StringContent(requestBody, Encoding.UTF8, "application/json")
                     Using resp = Await client.PostAsync(ApiUrl("search/metadata"), content, cancellationToken).ConfigureAwait(False)
                         resp.EnsureSuccessStatusCode()
@@ -949,6 +946,18 @@ Namespace Services
                 DiagnosticLogService.LogException("Immich.GetAssetsPage", ex)
             End Try
             Return result
+        End Function
+
+        ''' <summary>Gemeinsamer, rein funktionaler Aufbau des Requests für die Galerie-Timeline.
+        ''' Als eigene Naht lässt sich der API-Vertrag ohne einen laufenden Immich-Server prüfen.</summary>
+        Private Shared Function BuildAssetPageSearchBody(page As Integer, albumId As String,
+                                                         personId As String, city As String) As String
+            Dim filters As New List(Of String)()
+            If Not String.IsNullOrWhiteSpace(albumId) Then filters.Add($"""albumIds"":[""{albumId}""]")
+            If Not String.IsNullOrWhiteSpace(personId) Then filters.Add($"""personIds"":[""{personId}""]")
+            If Not String.IsNullOrWhiteSpace(city) Then filters.Add($"""city"":{JsonSerializer.Serialize(city)}")
+            Dim filterPrefix = If(filters.Count > 0, String.Join(",", filters) & ",", "")
+            Return $"{{{filterPrefix}""page"":{Math.Max(1, page)},""size"":{AssetPageSize},""withExif"":true}}"
         End Function
 
         ''' <summary>Benannte Personen der serverseitigen Gesichtserkennung (GET /api/people).
@@ -1058,6 +1067,7 @@ Namespace Services
                 .FileName = If(a.OriginalFileName, a.Id),
                 .IsVideo = String.Equals(a.Type, "VIDEO", StringComparison.OrdinalIgnoreCase),
                 .FileCreatedAt = ParseDate(a.FileCreatedAt),
+                .FileModifiedAt = ParseDate(a.FileModifiedAt),
                 .IsFavorite = a.IsFavorite,
                 .UpdatedAt = If(a.UpdatedAt, ""),
                 .Description = If(a.ExifInfo?.Description, "")
@@ -1068,6 +1078,7 @@ Namespace Services
             If a.ExifInfo IsNot Nothing Then
                 item.FileSizeBytes = If(a.ExifInfo.FileSizeInByte.HasValue, CLng(a.ExifInfo.FileSizeInByte.Value), 0L)
                 item.ExifDateTaken = ParseDate(a.ExifInfo.DateTimeOriginal)
+                item.ExifDateModified = ParseDate(a.ExifInfo.ModifyDate)
                 item.Iso = If(a.ExifInfo.Iso.HasValue, CInt(Math.Round(a.ExifInfo.Iso.Value)), CType(Nothing, Integer?))
                 item.Aperture = a.ExifInfo.FNumber
                 ' Immich (v3): 1-5 gültig, null/-1 = unbewertet. Auf FerrumPix 0-5 abbilden.
@@ -1085,6 +1096,14 @@ Namespace Services
             End If
             ApplyFerrumPixDescriptionMeta(item)
             Return item
+        End Function
+
+        ''' <summary>Schmale Diagnose-Naht für die JSON-Vertragsregressionen der Immich-Anbindung.
+        ''' Verwendet absichtlich denselben DTO- und Mapping-Pfad wie echte Serverantworten.</summary>
+        Private Shared Function MapAssetJsonForDiagnostics(json As String) As ImmichAsset
+            Dim dto = JsonSerializer.Deserialize(Of ImmichAssetDto)(json, JsonOptions)
+            If dto Is Nothing Then Return Nothing
+            Return MapAsset(dto)
         End Function
 
         Private Const FerrumPixMetaStart As String = "[FerrumPix]"
@@ -1690,6 +1709,7 @@ Namespace Services
             Public Property Visibility As String
             Public Property OriginalFileName As String
             Public Property FileCreatedAt As String
+            Public Property FileModifiedAt As String
             Public Property UpdatedAt As String
             Public Property IsFavorite As Boolean
             ' Maße/Dauer liegen bei der Metadaten-Suche auf oberster Ebene (kein exifInfo), beim
@@ -1711,6 +1731,7 @@ Namespace Services
             Public Property Iso As Double?
             Public Property FNumber As Double?
             Public Property DateTimeOriginal As String
+            Public Property ModifyDate As String
             Public Property Description As String
             Public Property Rating As Double?
             Public Property FileSizeInByte As Double?

--- a/ViewModels/GalleryViewModel.vb
+++ b/ViewModels/GalleryViewModel.vb
@@ -2233,15 +2233,14 @@ Namespace ViewModels
                     If result.Items.Count > 0 Then
                         Dim isFirstBatch = (total = 0)
                         If serverAssets IsNot Nothing Then serverAssets.AddRange(result.Items)
-                        ' Bereits aus dem Katalog angezeigte Assets: nur Kernfelder nachziehen, die
-                        ' die Timeline/Kacheln sofort betreffen (Favorit) - der Rest heilt sich
-                        ' viewport-gekoppelt ueber updatedAt selbst.
+                        ' Bereits aus dem Katalog angezeigte Assets vollständig nachziehen. Ältere
+                        ' Katalogversionen enthielten weder Dateigröße noch EXIF-/Änderungszeiten;
+                        ' nur den Favoriten zu aktualisieren ließ diese Einträge trotz vollständiger
+                        ' Serverantwort dauerhaft bei 0 B bzw. „Ohne Datum".
                         If itemsByAssetId IsNot Nothing Then
                             For Each asset In result.Items
                                 Dim known As ImageItem = Nothing
-                                If itemsByAssetId.TryGetValue(asset.Id, known) AndAlso known.IsFavorite <> asset.IsFavorite Then
-                                    known.IsFavorite = asset.IsFavorite
-                                End If
+                                If itemsByAssetId.TryGetValue(asset.Id, known) Then known.ApplyImmichMetadata(asset, replaceMissingDates:=True)
                             Next
                         End If
                         Dim items = result.Items.Select(Function(a) ImageItem.CreateImmichItem(a, thumbnailToken)).ToList()


### PR DESCRIPTION
## Summary

- request EXIF data when loading Immich timeline pages
- map file creation, modification, size, and EXIF date fields into gallery items
- migrate the Immich cache schema without discarding existing databases
- persist the additional metadata required for stable date and size sorting
- refresh complete metadata for items already loaded from the local catalog

## Root cause

Timeline requests did not ask Immich to include EXIF data, and the local cache omitted several file and EXIF fields used by gallery sorting. When server results refreshed an item already present in the catalog, only its favorite state was updated, leaving stale or empty sort metadata in place.

## User impact

Immich-backed galleries retain accurate file size and timestamp metadata across reloads. Date and size sorting no longer changes behavior depending on whether an item came from the server response or the local cache.

## Validation

- `dotnet build FerrumPix.sln`
- reviewed the complete schema migration, mapping, cache read/write, and gallery refresh diff
- `git diff --check upstream/main...fix/exif-info-and-sort`
