### PR TITLE
Render libmpv video through Avalonia's OpenGL control

### DIFF
--- a/Controls/MpvVideoView.vb
+++ b/Controls/MpvVideoView.vb
@@ -1,14 +1,18 @@
+Imports Avalonia
 Imports Avalonia.Controls
-Imports Avalonia.Platform
+Imports Avalonia.OpenGL
+Imports Avalonia.OpenGL.Controls
+Imports Avalonia.Threading
 Imports FerrumPix.Services
 
 Namespace Controls
 
     Public Class MpvVideoView
-        Inherits NativeControlHost
+        Inherits OpenGlControlBase
 
         Private _player As MpvPlayer
-        Private _platformHandle As IPlatformHandle
+        Private _attachedPlayer As MpvPlayer
+        Private _glReady As Boolean
 
         Public Property Player As MpvPlayer
             Get
@@ -16,28 +20,57 @@ Namespace Controls
             End Get
             Set(value As MpvPlayer)
                 If Object.ReferenceEquals(_player, value) Then Return
-                If _player IsNot Nothing AndAlso value Is Nothing Then
-                    _player.DetachWindow()
-                End If
                 _player = value
-                AttachPlayer()
+                If _glReady Then RequestNextFrameRendering()
             End Set
         End Property
 
-        Protected Overrides Function CreateNativeControlCore(parent As IPlatformHandle) As IPlatformHandle
-            _platformHandle = MyBase.CreateNativeControlCore(parent)
-            AttachPlayer()
-            Return _platformHandle
-        End Function
-
-        Protected Overrides Sub DestroyNativeControlCore(control As IPlatformHandle)
-            _platformHandle = Nothing
-            MyBase.DestroyNativeControlCore(control)
+        Protected Overrides Sub OnOpenGlInit(gl As GlInterface)
+            _glReady = True
+            SwitchPlayer(gl)
+            RequestNextFrameRendering()
         End Sub
 
-        Private Sub AttachPlayer()
-            If _player Is Nothing OrElse _platformHandle Is Nothing Then Return
-            _player.AttachWindow(_platformHandle.Handle)
+        Protected Overrides Sub OnOpenGlRender(gl As GlInterface, framebuffer As Integer)
+            SwitchPlayer(gl)
+            If _attachedPlayer Is Nothing Then Return
+
+            Dim host = Avalonia.Controls.TopLevel.GetTopLevel(Me)
+            Dim scaling = If(host Is Nothing, 1.0, host.RenderScaling)
+            Dim width = Math.Max(1, CInt(Math.Ceiling(Bounds.Width * scaling)))
+            Dim height = Math.Max(1, CInt(Math.Ceiling(Bounds.Height * scaling)))
+            _attachedPlayer.RenderOpenGlFrame(framebuffer, width, height)
+        End Sub
+
+        Protected Overrides Sub OnOpenGlDeinit(gl As GlInterface)
+            DetachPlayer()
+            _glReady = False
+        End Sub
+
+        Private Sub SwitchPlayer(gl As GlInterface)
+            If _attachedPlayer IsNot Nothing AndAlso
+               (Not Object.ReferenceEquals(_attachedPlayer, _player) OrElse _attachedPlayer.IsDisposeRequested) Then
+                DetachPlayer()
+            End If
+
+            If _attachedPlayer Is Nothing AndAlso _player IsNot Nothing AndAlso Not _player.IsDisposeRequested Then
+                Dim attached = _player.AttachOpenGl(
+                    Function(name) gl.GetProcAddress(name),
+                    Sub()
+                        Dispatcher.UIThread.Post(
+                            Sub()
+                                If _glReady Then RequestNextFrameRendering()
+                            End Sub,
+                            DispatcherPriority.Render)
+                    End Sub)
+                If attached Then _attachedPlayer = _player
+            End If
+        End Sub
+
+        Private Sub DetachPlayer()
+            If _attachedPlayer Is Nothing Then Return
+            _attachedPlayer.DetachOpenGl()
+            _attachedPlayer = Nothing
         End Sub
     End Class
 

--- a/Controls/MpvVideoView.vb
+++ b/Controls/MpvVideoView.vb
@@ -7,6 +7,11 @@ Imports FerrumPix.Services
 
 Namespace Controls
 
+    ''' <summary>
+    ''' Hosts libmpv's OpenGL render API in Avalonia's control tree.
+    ''' No native child window or platform window ID is created; Avalonia supplies
+    ''' the current framebuffer to the render callback on every desktop platform.
+    ''' </summary>
     Public Class MpvVideoView
         Inherits OpenGlControlBase
 
@@ -26,12 +31,16 @@ Namespace Controls
         End Property
 
         Protected Overrides Sub OnOpenGlInit(gl As GlInterface)
+            ' Avalonia has made its OpenGL context current before this callback.
+            ' Attach the player here, rather than from the UI thread.
             _glReady = True
             SwitchPlayer(gl)
             RequestNextFrameRendering()
         End Sub
 
         Protected Overrides Sub OnOpenGlRender(gl As GlInterface, framebuffer As Integer)
+            ' Both the framebuffer and libmpv's OpenGL render context are valid only
+            ' while Avalonia is executing this callback with its context current.
             SwitchPlayer(gl)
             If _attachedPlayer Is Nothing Then Return
 
@@ -43,11 +52,15 @@ Namespace Controls
         End Sub
 
         Protected Overrides Sub OnOpenGlDeinit(gl As GlInterface)
+            ' Release libmpv before Avalonia destroys this context. A render context
+            ' belongs to one host context and must not be reused after deinitialization.
             DetachPlayer()
             _glReady = False
         End Sub
 
         Private Sub SwitchPlayer(gl As GlInterface)
+            ' Navigation or disposal can replace the player while this control remains
+            ' in the visual tree. Remove stale callbacks before attaching the new player.
             If _attachedPlayer IsNot Nothing AndAlso
                (Not Object.ReferenceEquals(_attachedPlayer, _player) OrElse _attachedPlayer.IsDisposeRequested) Then
                 DetachPlayer()

--- a/Program.vb
+++ b/Program.vb
@@ -25,6 +25,12 @@ Module Program
             UsePlatformDetect().
             UseReactiveUI(AddressOf ConfigureReactiveUI).
             LogToTrace().
+            With(New AvaloniaNativePlatformOptions With {
+                .RenderingMode = New AvaloniaNativeRenderingMode() {
+                    AvaloniaNativeRenderingMode.OpenGl,
+                    AvaloniaNativeRenderingMode.Software
+                }
+            }).
             With(New X11PlatformOptions With {.UseDBusMenu = False})
     End Function
 

--- a/Program.vb
+++ b/Program.vb
@@ -21,6 +21,9 @@ Module Program
     End Function
 
     Function BuildAvaloniaApp() As AppBuilder
+        ' Video rendering uses Avalonia's OpenGL control on every desktop platform.
+        ' Keep OpenGL preferred and retain Software as Avalonia's fallback; the
+        ' libmpv Render API itself still needs a real OpenGL context for video.
         Return AppBuilder.Configure(Of App)().
             UsePlatformDetect().
             UseReactiveUI(AddressOf ConfigureReactiveUI).

--- a/Services/MpvInterop.vb
+++ b/Services/MpvInterop.vb
@@ -40,12 +40,10 @@ Namespace Services
             Return IntPtr.Zero
         End Function
 
-        ''' <summary>Erst die Bibliothek des Systems, dann die mitgelieferte.
-        '''
-        ''' Die Reihenfolge ist Absicht: eine vom Paketverwalter gepflegte libmpv bekommt
-        ''' Sicherheitsaktualisierungen und passt zu den Codecs, Treibern und Ausgabepfaden des
-        ''' Systems. Die mitgelieferte Fassung ist der Rückfall für Umgebungen, die keine haben -
-        ''' Windows und die portablen Pakete.</summary>
+        ''' <summary>Try system libmpv before application-local candidates.
+        ''' This lets package-managed security, codec, and driver updates follow the host.
+        ''' If no system library is available, the normal bundled/runtime candidates remain
+        ''' available for Windows and portable packages.</summary>
         Private Shared Function TryLoadPreferSystem(assembly As Assembly, searchPath As DllImportSearchPath?, ByRef handle As IntPtr) As Boolean
             For Each candidate In SystemLibraryCandidates()
                 If NativeLibrary.TryLoad(candidate, assembly, searchPath, handle) Then Return True

--- a/Services/MpvInterop.vb
+++ b/Services/MpvInterop.vb
@@ -131,6 +131,40 @@ Namespace Services
             Redirect = 5
         End Enum
 
+        Friend Enum MpvRenderParamType As Integer
+            Invalid = 0
+            ApiType = 1
+            OpenGlInitParams = 2
+            OpenGlFbo = 3
+            FlipY = 4
+        End Enum
+
+        <UnmanagedFunctionPointer(CallingConvention.Cdecl)>
+        Friend Delegate Function MpvOpenGlGetProcAddress(context As IntPtr, name As IntPtr) As IntPtr
+
+        <UnmanagedFunctionPointer(CallingConvention.Cdecl)>
+        Friend Delegate Sub MpvRenderUpdateCallback(context As IntPtr)
+
+        <StructLayout(LayoutKind.Sequential)>
+        Friend Structure MpvRenderParam
+            Public Type As MpvRenderParamType
+            Public Data As IntPtr
+        End Structure
+
+        <StructLayout(LayoutKind.Sequential)>
+        Friend Structure MpvOpenGlInitParams
+            Public GetProcAddress As MpvOpenGlGetProcAddress
+            Public GetProcAddressContext As IntPtr
+        End Structure
+
+        <StructLayout(LayoutKind.Sequential)>
+        Friend Structure MpvOpenGlFbo
+            Public Fbo As Integer
+            Public Width As Integer
+            Public Height As Integer
+            Public InternalFormat As Integer
+        End Structure
+
         <StructLayout(LayoutKind.Sequential)>
         Friend Structure MpvEvent
             Public EventId As MpvEventId
@@ -186,6 +220,35 @@ Namespace Services
         <DllImport("libmpv", EntryPoint:="mpv_wait_event", CallingConvention:=CallingConvention.Cdecl)>
         Friend Shared Function WaitEvent(handle As IntPtr, timeout As Double) As IntPtr
         End Function
+
+        <DllImport("libmpv", EntryPoint:="mpv_render_context_create", CallingConvention:=CallingConvention.Cdecl)>
+        Friend Shared Function RenderContextCreate(ByRef context As IntPtr,
+                                                   handle As IntPtr,
+                                                   <[In]> parameters As MpvRenderParam()) As Integer
+        End Function
+
+        <DllImport("libmpv", EntryPoint:="mpv_render_context_set_update_callback", CallingConvention:=CallingConvention.Cdecl)>
+        Friend Shared Sub RenderContextSetUpdateCallback(context As IntPtr,
+                                                         callback As MpvRenderUpdateCallback,
+                                                         callbackContext As IntPtr)
+        End Sub
+
+        <DllImport("libmpv", EntryPoint:="mpv_render_context_update", CallingConvention:=CallingConvention.Cdecl)>
+        Friend Shared Function RenderContextUpdate(context As IntPtr) As ULong
+        End Function
+
+        <DllImport("libmpv", EntryPoint:="mpv_render_context_render", CallingConvention:=CallingConvention.Cdecl)>
+        Friend Shared Function RenderContextRender(context As IntPtr,
+                                                   <[In]> parameters As MpvRenderParam()) As Integer
+        End Function
+
+        <DllImport("libmpv", EntryPoint:="mpv_render_context_report_swap", CallingConvention:=CallingConvention.Cdecl)>
+        Friend Shared Sub RenderContextReportSwap(context As IntPtr)
+        End Sub
+
+        <DllImport("libmpv", EntryPoint:="mpv_render_context_free", CallingConvention:=CallingConvention.Cdecl)>
+        Friend Shared Sub RenderContextFree(context As IntPtr)
+        End Sub
     End Class
 
 End Namespace

--- a/Services/MpvInterop.vb
+++ b/Services/MpvInterop.vb
@@ -47,10 +47,32 @@ Namespace Services
         ''' Systems. Die mitgelieferte Fassung ist der Rückfall für Umgebungen, die keine haben -
         ''' Windows und die portablen Pakete.</summary>
         Private Shared Function TryLoadPreferSystem(assembly As Assembly, searchPath As DllImportSearchPath?, ByRef handle As IntPtr) As Boolean
-            For Each candidate In LibraryNames()
+            For Each candidate In SystemLibraryCandidates()
                 If NativeLibrary.TryLoad(candidate, assembly, searchPath, handle) Then Return True
             Next
             Return TryLoadBundledLibrary(handle)
+        End Function
+
+        Private Shared Iterator Function SystemLibraryCandidates() As IEnumerable(Of String)
+            Dim names = LibraryNames()
+            For Each name In names
+                Yield name
+            Next
+
+            If Not OperatingSystem.IsMacOS() Then Return
+
+            Dim libraryDirectories = {
+                "/opt/homebrew/opt/mpv/lib",
+                "/opt/homebrew/lib",
+                "/usr/local/opt/mpv/lib",
+                "/usr/local/lib",
+                "/opt/local/lib"
+            }
+            For Each directory In libraryDirectories
+                For Each name In names
+                    Yield Path.Combine(directory, name)
+                Next
+            Next
         End Function
 
         Private Shared Function LibraryNames() As String()

--- a/Services/MpvPlayer.vb
+++ b/Services/MpvPlayer.vb
@@ -17,9 +17,8 @@ Namespace Services
 
         Private ReadOnly _syncRoot As New Object()
         Private ReadOnly _enableHardwareAcceleration As Boolean
-        ' Regular libmpv commands run separately from the OpenGL render thread.
-        ' The render API requires this separation, and file or seek commands must
-        ' not block Avalonia's UI thread.
+        ' Serialize libmpv commands on a dedicated thread. Render API calls remain on
+        ' Avalonia's OpenGL callback path, and file/seek commands must not block the UI.
         Private ReadOnly _commandQueue As New BlockingCollection(Of Action)()
         Private ReadOnly _commandThread As Thread
         Private ReadOnly _commandQueueLock As New Object()
@@ -64,8 +63,9 @@ Namespace Services
             End Get
         End Property
 
-        ''' <summary>Attaches libmpv to Avalonia's current OpenGL context.
-        ''' Call only from OpenGlControlBase.OnOpenGl* methods.</summary>
+        ''' <summary>Creates the libmpv render context for Avalonia's current OpenGL context.
+        ''' Call only from MpvVideoView's OpenGlControlBase.OnOpenGl* callbacks; the
+        ''' supplied function pointers and render callbacks are tied to that context.</summary>
         Friend Function AttachOpenGl(getProcAddress As Func(Of String, IntPtr), requestRender As Action) As Boolean
             If getProcAddress Is Nothing OrElse requestRender Is Nothing Then Return False
 
@@ -140,7 +140,9 @@ Namespace Services
             End Try
         End Function
 
-        ''' <summary>Detaches the renderer while Avalonia still holds its OpenGL context current.</summary>
+        ''' <summary>Releases the libmpv render context while Avalonia still holds its
+        ''' OpenGL context current. Native player destruction is deferred when disposal
+        ''' was requested while the render context was still attached.</summary>
         Friend Sub DetachOpenGl()
             Dim context As IntPtr
             Dim shouldDispose As Boolean
@@ -164,8 +166,9 @@ Namespace Services
             If shouldDispose Then QueueDispose()
         End Sub
 
-        ''' <summary>Renders the next frame into Avalonia's current framebuffer.
-        ''' Call only from OpenGlControlBase.OnOpenGlRender.</summary>
+        ''' <summary>Renders the next frame into the framebuffer supplied by Avalonia.
+        ''' Width and height are physical pixels. Call only from
+        ''' OpenGlControlBase.OnOpenGlRender while the host context is current.</summary>
         Friend Function RenderOpenGlFrame(framebuffer As Integer, width As Integer, height As Integer) As Boolean
             Dim context As IntPtr
             SyncLock _syncRoot
@@ -360,6 +363,8 @@ Namespace Services
             ' Treat the option as optional for compatibility with minimal libmpv builds.
             TrySetOptionStringLocked("osc", "no")
             SetOptionStringLocked("keep-open", "no")
+            ' Avalonia owns the drawing surface, so use libmpv's render API instead of
+            ' --wid. No platform-native child window is created by this player.
             SetOptionStringLocked("vo", "libmpv")
             ' Match image "cover" behavior: preserve aspect ratio while filling the
             ' output surface instead of retaining letterbox or pillarbox bars.

--- a/Services/MpvPlayer.vb
+++ b/Services/MpvPlayer.vb
@@ -1,4 +1,5 @@
 Imports System
+Imports System.Collections.Concurrent
 Imports System.Collections.Generic
 Imports System.Globalization
 Imports System.Runtime.InteropServices
@@ -16,11 +17,22 @@ Namespace Services
 
         Private ReadOnly _syncRoot As New Object()
         Private ReadOnly _enableHardwareAcceleration As Boolean
+        ' Regular libmpv commands run separately from the OpenGL render thread.
+        ' The render API requires this separation, and file or seek commands must
+        ' not block Avalonia's UI thread.
+        Private ReadOnly _commandQueue As New BlockingCollection(Of Action)()
+        Private ReadOnly _commandThread As Thread
+        Private ReadOnly _commandQueueLock As New Object()
+        Private _disposeQueued As Boolean = False
+        Private _disposeRequested As Boolean = False
 
         Private _handle As IntPtr = IntPtr.Zero
+        Private _renderContext As IntPtr = IntPtr.Zero
+        Private _getProcAddressCallback As MpvInterop.MpvOpenGlGetProcAddress
+        Private _renderUpdateCallback As MpvInterop.MpvRenderUpdateCallback
+        Private _requestRender As Action
         Private _eventThread As Thread
         Private _disposed As Boolean = False
-        Private _windowHandle As IntPtr = IntPtr.Zero
         Private _initialized As Boolean = False
         Private _pendingPath As String = Nothing
         Private _pendingPlay As Boolean = False
@@ -37,103 +49,260 @@ Namespace Services
 
         Public Sub New(enableHardwareAcceleration As Boolean)
             _enableHardwareAcceleration = enableHardwareAcceleration
+            _commandThread = New Thread(AddressOf CommandLoop) With {
+                .IsBackground = True,
+                .Name = "libmpv-command-loop"
+            }
+            _commandThread.Start()
         End Sub
 
-        Public Sub AttachWindow(windowHandle As IntPtr)
-            If windowHandle = IntPtr.Zero Then Return
+        Friend ReadOnly Property IsDisposeRequested As Boolean
+            Get
+                SyncLock _syncRoot
+                    Return _disposeRequested
+                End SyncLock
+            End Get
+        End Property
+
+        ''' <summary>Attaches libmpv to Avalonia's current OpenGL context.
+        ''' Call only from OpenGlControlBase.OnOpenGl* methods.</summary>
+        Friend Function AttachOpenGl(getProcAddress As Func(Of String, IntPtr), requestRender As Action) As Boolean
+            If getProcAddress Is Nothing OrElse requestRender Is Nothing Then Return False
 
             Try
                 SyncLock _syncRoot
-                    If _disposed OrElse _initializationFailed Then Return
-                    If _windowHandle = windowHandle AndAlso _initialized Then Return
-                    _windowHandle = windowHandle
-                    If Not _initialized Then
-                        InitializeLocked()
-                    ElseIf _handle <> IntPtr.Zero Then
-                        SetOptionStringLocked("wid", WindowHandleToUnsignedString(_windowHandle))
-                    End If
+                    If _disposed OrElse _disposeRequested OrElse _initializationFailed Then Return False
+                    If _renderContext <> IntPtr.Zero Then Return True
+
+                    InitializeCoreLocked()
+
+                    _getProcAddressCallback =
+                        Function(context As IntPtr, namePointer As IntPtr) As IntPtr
+                            Try
+                                Dim name = Marshal.PtrToStringUTF8(namePointer)
+                                If String.IsNullOrEmpty(name) Then Return IntPtr.Zero
+                                Return getProcAddress(name)
+                            Catch
+                                Return IntPtr.Zero
+                            End Try
+                        End Function
+
+                    _renderUpdateCallback =
+                        Sub(context As IntPtr)
+                            Try
+                                requestRender()
+                            Catch
+                            End Try
+                        End Sub
+                    _requestRender = requestRender
+
+                    Using apiType As New Utf8String("opengl")
+                        Dim initParams = New MpvInterop.MpvOpenGlInitParams With {
+                            .GetProcAddress = _getProcAddressCallback,
+                            .GetProcAddressContext = IntPtr.Zero
+                        }
+                        Dim initParamsPointer = Marshal.AllocHGlobal(Marshal.SizeOf(Of MpvInterop.MpvOpenGlInitParams)())
+                        Try
+                            Marshal.StructureToPtr(initParams, initParamsPointer, False)
+                            Dim parameters = {
+                                New MpvInterop.MpvRenderParam With {
+                                    .Type = MpvInterop.MpvRenderParamType.ApiType,
+                                    .Data = apiType.Pointer
+                                },
+                                New MpvInterop.MpvRenderParam With {
+                                    .Type = MpvInterop.MpvRenderParamType.OpenGlInitParams,
+                                    .Data = initParamsPointer
+                                },
+                                New MpvInterop.MpvRenderParam With {
+                                    .Type = MpvInterop.MpvRenderParamType.Invalid,
+                                    .Data = IntPtr.Zero
+                                }
+                            }
+                            Dim context As IntPtr = IntPtr.Zero
+                            Dim result = MpvInterop.RenderContextCreate(context, _handle, parameters)
+                            If result < 0 OrElse context = IntPtr.Zero Then
+                                Throw New InvalidOperationException($"Could not initialize the libmpv OpenGL renderer ({result}).")
+                            End If
+                            _renderContext = context
+                        Finally
+                            Marshal.FreeHGlobal(initParamsPointer)
+                        End Try
+                    End Using
+
+                    MpvInterop.RenderContextSetUpdateCallback(_renderContext, _renderUpdateCallback, IntPtr.Zero)
                 End SyncLock
+
+                LoadPending()
+                Return True
             Catch ex As Exception
                 HandleInitializationFailure(ex)
+                Return False
             End Try
+        End Function
+
+        ''' <summary>Detaches the renderer while Avalonia still holds its OpenGL context current.</summary>
+        Friend Sub DetachOpenGl()
+            Dim context As IntPtr
+            Dim shouldDispose As Boolean
+            SyncLock _syncRoot
+                context = _renderContext
+                _renderContext = IntPtr.Zero
+                _requestRender = Nothing
+                shouldDispose = _disposeRequested
+            End SyncLock
+
+            If context <> IntPtr.Zero Then
+                Try
+                    MpvInterop.RenderContextSetUpdateCallback(context, Nothing, IntPtr.Zero)
+                Catch
+                End Try
+                MpvInterop.RenderContextFree(context)
+            End If
+
+            _renderUpdateCallback = Nothing
+            _getProcAddressCallback = Nothing
+            If shouldDispose Then QueueDispose()
         End Sub
 
-        Public Sub DetachWindow()
+        ''' <summary>Renders the next frame into Avalonia's current framebuffer.
+        ''' Call only from OpenGlControlBase.OnOpenGlRender.</summary>
+        Friend Function RenderOpenGlFrame(framebuffer As Integer, width As Integer, height As Integer) As Boolean
+            Dim context As IntPtr
             SyncLock _syncRoot
-                _windowHandle = IntPtr.Zero
-                If _initializationFailed OrElse Not _initialized OrElse _handle = IntPtr.Zero Then Return
-                SetOptionStringLocked("wid", "-1")
+                context = _renderContext
             End SyncLock
-        End Sub
+            If context = IntPtr.Zero OrElse width <= 0 OrElse height <= 0 Then Return False
+
+            MpvInterop.RenderContextUpdate(context)
+
+            Dim fbo = New MpvInterop.MpvOpenGlFbo With {
+                .Fbo = framebuffer,
+                .Width = width,
+                .Height = height,
+                .InternalFormat = 0
+            }
+            Dim flipY As Integer = 1
+            Dim fboPointer = Marshal.AllocHGlobal(Marshal.SizeOf(Of MpvInterop.MpvOpenGlFbo)())
+            Dim flipPointer = Marshal.AllocHGlobal(Marshal.SizeOf(Of Integer)())
+            Try
+                Marshal.StructureToPtr(fbo, fboPointer, False)
+                Marshal.WriteInt32(flipPointer, flipY)
+                Dim parameters = {
+                    New MpvInterop.MpvRenderParam With {
+                        .Type = MpvInterop.MpvRenderParamType.OpenGlFbo,
+                        .Data = fboPointer
+                    },
+                    New MpvInterop.MpvRenderParam With {
+                        .Type = MpvInterop.MpvRenderParamType.FlipY,
+                        .Data = flipPointer
+                    },
+                    New MpvInterop.MpvRenderParam With {
+                        .Type = MpvInterop.MpvRenderParamType.Invalid,
+                        .Data = IntPtr.Zero
+                    }
+                }
+                Dim result = MpvInterop.RenderContextRender(context, parameters)
+                If result >= 0 Then MpvInterop.RenderContextReportSwap(context)
+                Return result >= 0
+            Finally
+                Marshal.FreeHGlobal(flipPointer)
+                Marshal.FreeHGlobal(fboPointer)
+            End Try
+        End Function
 
         Public Sub Load(path As String)
             If String.IsNullOrWhiteSpace(path) Then Return
-
-            SyncLock _syncRoot
-                _pendingPath = path
-                If _initializationFailed OrElse Not _initialized OrElse _windowHandle = IntPtr.Zero Then Return
-                SetPauseLocked(True)
-                Dim result = CommandLocked("loadfile", path, "replace")
-                If result >= 0 AndAlso _pendingPlay Then SetPauseLocked(False)
-            End SyncLock
+            EnqueueCommand(
+                Sub()
+                    SyncLock _syncRoot
+                        _pendingPath = path
+                        If _initializationFailed OrElse Not _initialized OrElse _renderContext = IntPtr.Zero Then Return
+                        SetPauseLocked(True)
+                        Dim result = CommandLocked("loadfile", path, "replace")
+                        If result >= 0 AndAlso _pendingPlay Then SetPauseLocked(False)
+                    End SyncLock
+                End Sub)
         End Sub
 
         Public Sub LoadPending()
-            SyncLock _syncRoot
-                If String.IsNullOrWhiteSpace(_pendingPath) Then Return
-                If _initializationFailed OrElse Not _initialized OrElse _windowHandle = IntPtr.Zero Then Return
-                SetPauseLocked(True)
-                Dim result = CommandLocked("loadfile", _pendingPath, "replace")
-                If result >= 0 AndAlso _pendingPlay Then SetPauseLocked(False)
-            End SyncLock
+            EnqueueCommand(
+                Sub()
+                    SyncLock _syncRoot
+                        If String.IsNullOrWhiteSpace(_pendingPath) Then Return
+                        If _initializationFailed OrElse Not _initialized OrElse _renderContext = IntPtr.Zero Then Return
+                        SetPauseLocked(True)
+                        Dim result = CommandLocked("loadfile", _pendingPath, "replace")
+                        If result >= 0 AndAlso _pendingPlay Then SetPauseLocked(False)
+                    End SyncLock
+                End Sub)
         End Sub
 
         Public Sub Play()
-            SyncLock _syncRoot
-                _pendingPlay = True
-                If _initialized AndAlso Not _initializationFailed Then SetPauseLocked(False)
-            End SyncLock
+            EnqueueCommand(
+                Sub()
+                    SyncLock _syncRoot
+                        _pendingPlay = True
+                        If _initialized AndAlso Not _initializationFailed Then SetPauseLocked(False)
+                    End SyncLock
+                End Sub)
         End Sub
 
         Public Sub Pause()
-            SyncLock _syncRoot
-                _pendingPlay = False
-                If _initialized AndAlso Not _initializationFailed Then SetPauseLocked(True)
-            End SyncLock
-        End Sub
-
-        Public Sub TogglePause()
-            SyncLock _syncRoot
-                If _initializationFailed Then Return
-                If _isPaused Then
-                    _pendingPlay = True
-                    If _initialized Then SetPauseLocked(False)
-                Else
-                    _pendingPlay = False
-                    If _initialized Then SetPauseLocked(True)
-                End If
-            End SyncLock
+            EnqueueCommand(
+                Sub()
+                    SyncLock _syncRoot
+                        _pendingPlay = False
+                        If _initialized AndAlso Not _initializationFailed Then SetPauseLocked(True)
+                    End SyncLock
+                End Sub)
         End Sub
 
         Public Sub [Stop]()
-            SyncLock _syncRoot
-                _pendingPlay = False
-                If _initialized AndAlso Not _initializationFailed Then CommandLocked("stop")
-            End SyncLock
+            EnqueueCommand(
+                Sub()
+                    SyncLock _syncRoot
+                        _pendingPlay = False
+                        If _initialized AndAlso Not _initializationFailed Then CommandLocked("stop")
+                    End SyncLock
+                End Sub)
         End Sub
 
         Public Sub Seek(seconds As Double)
-            SyncLock _syncRoot
-                If _initializationFailed OrElse Not _initialized Then Return
-                SetPropertyStringLocked("time-pos", Math.Max(0, seconds).ToString(CultureInfo.InvariantCulture))
-            End SyncLock
+            EnqueueCommand(
+                Sub()
+                    SyncLock _syncRoot
+                        If _initializationFailed OrElse Not _initialized Then Return
+                        SetPropertyStringLocked("time-pos", Math.Max(0, seconds).ToString(CultureInfo.InvariantCulture))
+                    End SyncLock
+                End Sub)
         End Sub
 
         Public Sub SetMuted(value As Boolean)
-            SyncLock _syncRoot
-                _isMuted = value
-                If _initialized AndAlso Not _initializationFailed Then SetPropertyStringLocked("mute", If(value, "yes", "no"))
+            EnqueueCommand(
+                Sub()
+                    SyncLock _syncRoot
+                        _isMuted = value
+                        If _initialized AndAlso Not _initializationFailed Then SetPropertyStringLocked("mute", If(value, "yes", "no"))
+                    End SyncLock
+                End Sub)
+        End Sub
+
+        Private Sub EnqueueCommand(workItem As Action)
+            If workItem Is Nothing Then Return
+            SyncLock _commandQueueLock
+                If _disposeRequested OrElse _disposeQueued OrElse _commandQueue.IsAddingCompleted Then Return
+                _commandQueue.Add(workItem)
             End SyncLock
+        End Sub
+
+        Private Sub CommandLoop()
+            For Each workItem In _commandQueue.GetConsumingEnumerable()
+                Try
+                    workItem()
+                Catch ex As Exception
+                    DiagnosticLogService.LogException("VideoPlayback.Command", ex)
+                End Try
+            Next
         End Sub
 
         Private Sub HandleInitializationFailure(ex As Exception)
@@ -143,7 +312,6 @@ Namespace Services
                 _initializationFailed = True
                 _disposed = True
                 _initialized = False
-                _windowHandle = IntPtr.Zero
                 handleToDestroy = _handle
                 eventThread = _eventThread
             End SyncLock
@@ -176,8 +344,8 @@ Namespace Services
             RaiseEvent InitializationFailed(ex)
         End Sub
 
-        Private Sub InitializeLocked()
-            If _initializationFailed OrElse _initialized OrElse _windowHandle = IntPtr.Zero Then Return
+        Private Sub InitializeCoreLocked()
+            If _initializationFailed OrElse _initialized Then Return
 
             MpvInterop.EnsureResolver()
             _handle = MpvInterop.Create()
@@ -188,14 +356,15 @@ Namespace Services
             SetOptionStringLocked("msg-level", "all=no")
             SetOptionStringLocked("config", "no")
             SetOptionStringLocked("input-default-bindings", "no")
-            SetOptionStringLocked("osc", "no")
+            ' FerrumPix provides its own controls and does not need mpv's OSC.
+            ' Treat the option as optional for compatibility with minimal libmpv builds.
+            TrySetOptionStringLocked("osc", "no")
             SetOptionStringLocked("keep-open", "no")
+            SetOptionStringLocked("vo", "libmpv")
+            ' Match image "cover" behavior: preserve aspect ratio while filling the
+            ' output surface instead of retaining letterbox or pillarbox bars.
+            SetOptionStringLocked("panscan", "1.0")
             SetOptionStringLocked("hwdec", If(_enableHardwareAcceleration, "auto-safe", "no"))
-            If OperatingSystem.IsLinux() Then
-                SetOptionStringLocked("vo", "gpu")
-                SetOptionStringLocked("gpu-context", "x11egl")
-            End If
-            SetOptionStringLocked("wid", WindowHandleToUnsignedString(_windowHandle))
 
             Dim result = MpvInterop.Initialize(_handle)
             If result < 0 Then Throw New InvalidOperationException($"libmpv konnte nicht initialisiert werden ({result}).")
@@ -205,13 +374,6 @@ Namespace Services
             ObservePropertyLocked(PropPause, "pause", MpvInterop.MpvFormat.Flag)
             ObservePropertyLocked(PropMute, "mute", MpvInterop.MpvFormat.Flag)
             SetPropertyStringLocked("mute", If(_isMuted, "yes", "no"))
-
-            ' Klick aufs Video toggelt Wiedergabe/Pause: Das Video sitzt in
-            ' einem NativeControlHost - Avalonia-Pointer-Events erreichen es NIE, das native
-            ' mpv-Fenster schluckt sie. Deshalb bindet mpv selbst die linke Maustaste; alle uebrigen
-            ' Default-Bindings bleiben aus (input-default-bindings=no). Der Pause-Status fliesst
-            ' ueber die bestehende pause-Observation zurueck in die Oberflaeche (Play-Knopf folgt).
-            CommandLocked("keybind", "MBTN_LEFT", "cycle pause")
 
             _eventThread = New Thread(AddressOf EventLoop) With {
                 .IsBackground = True,
@@ -315,6 +477,12 @@ Namespace Services
             End Using
         End Sub
 
+        Private Function TrySetOptionStringLocked(name As String, value As String) As Boolean
+            Using namePtr = New Utf8String(name), valuePtr = New Utf8String(value)
+                Return MpvInterop.SetOptionString(_handle, namePtr.Pointer, valuePtr.Pointer) >= 0
+            End Using
+        End Function
+
         Private Sub SetPropertyStringLocked(name As String, value As String)
             Using namePtr = New Utf8String(name), valuePtr = New Utf8String(value)
                 MpvInterop.SetPropertyString(_handle, namePtr.Pointer, valuePtr.Pointer)
@@ -326,20 +494,35 @@ Namespace Services
             SetPropertyStringLocked("pause", If(value, "yes", "no"))
         End Sub
 
-        Private Shared Function WindowHandleToUnsignedString(handle As IntPtr) As String
-            If OperatingSystem.IsLinux() Then
-                Return CUInt(handle.ToInt64() And &HFFFFFFFFL).ToString(CultureInfo.InvariantCulture)
-            End If
-
-            If IntPtr.Size <= 4 Then
-                Return CUInt(handle.ToInt32()).ToString(CultureInfo.InvariantCulture)
-            End If
-
-            Dim bytes = BitConverter.GetBytes(handle.ToInt64())
-            Return BitConverter.ToUInt64(bytes, 0).ToString(CultureInfo.InvariantCulture)
-        End Function
-
         Public Sub Dispose() Implements IDisposable.Dispose
+            Dim requestRender As Action
+            Dim canDisposeNow As Boolean
+            SyncLock _syncRoot
+                If _disposeRequested Then Return
+                _disposeRequested = True
+                requestRender = _requestRender
+                canDisposeNow = _renderContext = IntPtr.Zero
+            End SyncLock
+
+            If requestRender IsNot Nothing Then
+                Try
+                    requestRender()
+                Catch
+                End Try
+            End If
+            If canDisposeNow Then QueueDispose()
+        End Sub
+
+        Private Sub QueueDispose()
+            SyncLock _commandQueueLock
+                If _disposeQueued Then Return
+                _disposeQueued = True
+                _commandQueue.Add(AddressOf DisposeCore)
+                _commandQueue.CompleteAdding()
+            End SyncLock
+        End Sub
+
+        Private Sub DisposeCore()
             Dim handleToDestroy As IntPtr = IntPtr.Zero
             Dim eventThread As Thread = Nothing
 

--- a/Styles/FerrumPixTheme.axaml
+++ b/Styles/FerrumPixTheme.axaml
@@ -490,6 +490,15 @@
     <Style Selector="Button.icon-btn:pointerover /template/ ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource FP.Bg.Elevated}"/>
     </Style>
+    <!-- Video controls sit on a dark translucent surface. White identifies an
+         available command, while the accent color keeps hover state visible
+         independently of the frame behind it. -->
+    <Style Selector="Button.icon-btn.video-control icons|SvgIcon">
+        <Setter Property="IconBrush" Value="White"/>
+    </Style>
+    <Style Selector="Button.icon-btn.video-control:pointerover icons|SvgIcon">
+        <Setter Property="IconBrush" Value="{DynamicResource FP.Accent.Light}"/>
+    </Style>
     <Style Selector="Button.icon-btn.active">
         <Setter Property="Foreground" Value="{DynamicResource FP.Accent}"/>
         <Setter Property="Background" Value="Transparent"/>

--- a/ViewModels/EditorViewModel.vb
+++ b/ViewModels/EditorViewModel.vb
@@ -13959,6 +13959,12 @@ Namespace ViewModels
             End Get
         End Property
 
+        Public ReadOnly Property ShowHistogram As Boolean
+            Get
+                Return True
+            End Get
+        End Property
+
         Public ReadOnly Property InfoPlaceholderText As String
             Get
                 Return ""

--- a/ViewModels/InfoPanelViewModel.vb
+++ b/ViewModels/InfoPanelViewModel.vb
@@ -180,7 +180,7 @@ Namespace ViewModels
 
         ''' <summary>Alles melden, was von Auswahl und Betriebsart abhaengt.</summary>
         Private Sub RaiseStateChanged()
-            For Each propertyName In {NameOf(IsSummary), NameOf(IsSingleImage), NameOf(HasInfoContent),
+            For Each propertyName In {NameOf(IsSummary), NameOf(IsSingleImage), NameOf(ShowHistogram), NameOf(HasInfoContent),
                                       NameOf(Name), NameOf(IsInfoTabGeneral), NameOf(IsInfoTabExif),
                                       NameOf(IsInfoTabIptc), NameOf(IsInfoTabXmp), NameOf(IsInfoTabIcc)}
                 Me.RaisePropertyChanged(propertyName)
@@ -198,6 +198,16 @@ Namespace ViewModels
         Public ReadOnly Property IsSingleImage As Boolean
             Get
                 Return Not _isSummary AndAlso Not String.IsNullOrEmpty(_path)
+            End Get
+        End Property
+
+        Public ReadOnly Property ShowHistogram As Boolean
+            Get
+                If Not IsSingleImage Then Return False
+                Dim mediaName = If(_item?.ImmichOriginalFileName, "")
+                If String.IsNullOrEmpty(mediaName) Then mediaName = If(_item?.FileName, "")
+                If String.IsNullOrEmpty(mediaName) Then mediaName = _path
+                Return Not VideoPreviewService.IsSupportedVideo(mediaName)
             End Get
         End Property
 

--- a/ViewModels/ViewerViewModel.vb
+++ b/ViewModels/ViewerViewModel.vb
@@ -694,6 +694,12 @@ Namespace ViewModels
             End Get
         End Property
 
+        Public ReadOnly Property ShowHistogram As Boolean
+            Get
+                Return Not IsVideoFile
+            End Get
+        End Property
+
         ''' Ob die Inline-Videowiedergabe im Viewer verfügbar ist. Für den Viewer wird libmpv
         ''' verwendet; fehlt die Bibliothek, zeigt die View stattdessen einen Hinweis.
         Public ReadOnly Property IsVideoPlaybackAvailable As Boolean
@@ -1068,6 +1074,7 @@ Namespace ViewModels
                 LoadInfoPanelData(_currentImagePath, preserveExistingTags:=True)
                 Me.RaisePropertyChanged(NameOf(IsRawFile))
                 Me.RaisePropertyChanged(NameOf(IsVideoFile))
+                Me.RaisePropertyChanged(NameOf(ShowHistogram))
                 Me.RaisePropertyChanged(NameOf(ShowVideoUnavailableNotice))
                 Me.RaisePropertyChanged(NameOf(HasNoMedia))
                 Me.RaisePropertyChanged(NameOf(CanEdit))
@@ -1704,6 +1711,7 @@ Namespace ViewModels
             UebernehmeKatalogAttribute(imagePath)
             Me.RaisePropertyChanged(NameOf(IsRawFile))
             Me.RaisePropertyChanged(NameOf(IsVideoFile))
+            Me.RaisePropertyChanged(NameOf(ShowHistogram))
             Me.RaisePropertyChanged(NameOf(ShowVideoUnavailableNotice))
             Me.RaisePropertyChanged(NameOf(HasNoMedia))
             Me.RaisePropertyChanged(NameOf(CanEdit))
@@ -1727,6 +1735,7 @@ Namespace ViewModels
             LoadInfoPanelData(_currentImagePath)
             Me.RaisePropertyChanged(NameOf(IsRawFile))
             Me.RaisePropertyChanged(NameOf(IsVideoFile))
+            Me.RaisePropertyChanged(NameOf(ShowHistogram))
             Me.RaisePropertyChanged(NameOf(ShowVideoUnavailableNotice))
             Me.RaisePropertyChanged(NameOf(HasNoMedia))
             Me.RaisePropertyChanged(NameOf(CanEdit))
@@ -1982,6 +1991,7 @@ Namespace ViewModels
             Try
                 _mediaPlayer?.LoadPending()
                 _mediaPlayer?.Play()
+                IsVideoPlaying = True
             Catch ex As Exception
                 DiagnosticLogService.LogException("VideoPlayback.StartPendingVideoAutoplay", ex)
             End Try
@@ -2024,7 +2034,13 @@ Namespace ViewModels
                 Return
             End If
 
-            _mediaPlayer.TogglePause()
+            If IsVideoPlaying Then
+                _mediaPlayer.Pause()
+                IsVideoPlaying = False
+            Else
+                _mediaPlayer.Play()
+                IsVideoPlaying = True
+            End If
         End Sub
 
         Private Sub SeekVideo(seconds As Double)
@@ -2072,6 +2088,10 @@ Namespace ViewModels
 
         Private Sub OnVideoEndReached(reason As Integer, [error] As Integer)
             Dispatcher.UIThread.Post(Sub()
+                                          ' Navigation and reload intentionally issue Stop, whose event can
+                                          ' arrive after the next file starts. The caller has already updated
+                                          ' the UI state, so a late Stop must not mark new playback as paused.
+                                          If reason = CInt(MpvInterop.MpvEndFileReason.Stop) Then Return
                                           If reason <> CInt(MpvInterop.MpvEndFileReason.Eof) Then
                                               IsVideoPlaying = False
                                               Return
@@ -2567,6 +2587,7 @@ Namespace ViewModels
             UebernehmeKatalogAttribute(_currentImagePath)
             Me.RaisePropertyChanged(NameOf(IsRawFile))
             Me.RaisePropertyChanged(NameOf(IsVideoFile))
+            Me.RaisePropertyChanged(NameOf(ShowHistogram))
             Me.RaisePropertyChanged(NameOf(ShowVideoUnavailableNotice))
             Me.RaisePropertyChanged(NameOf(HasNoMedia))
             Me.RaisePropertyChanged(NameOf(CanEdit))

--- a/Views/InfoSidebarView.axaml
+++ b/Views/InfoSidebarView.axaml
@@ -6,7 +6,7 @@
 
     <!-- Gemeinsame Info-Seitenleiste (Allgemein/EXIF/IPTC/XMP) für Viewer, Editor und Galerie -
          alle drei stellen dieselben Property-/Command-Namen bereit (ExifInfo, Tags, HistogramImage,
-         IsInfoTab*, ToggleFavoriteCommand, SetRatingCommand, SetColorLabelCommand, AddTagCommand,
+         IsInfoTab*, ShowHistogram, ToggleFavoriteCommand, SetRatingCommand, SetColorLabelCommand, AddTagCommand,
          RemoveTagCommand, Rating, IsFavorite, ColorLabel/IsColorLabel*, IsInfoSidebarVisible),
          daher genügt ein einziges, DataContext-loses UserControl statt der zuvor doppelt
          gepflegten Markup-Kopie in ViewerView/EditorView. Viewer und Editor tragen den Zustand
@@ -117,18 +117,17 @@
                             </Grid>
                         </StackPanel>
 
-                        <!-- Die Trennlinien gehoeren zu den Bloecken, die sie abgrenzen: sonst
-                             stehen bei ausgeblendetem Histogramm zwei uebereinander. -->
-                        <Border Height="1" Background="{DynamicResource FP.Border.Normal}"
-                                IsVisible="{Binding IsSingleImage}"/>
+                        <StackPanel Spacing="18" IsVisible="{Binding ShowHistogram}">
+                            <Border Height="1" Background="{DynamicResource FP.Border.Normal}"/>
 
-                        <StackPanel Spacing="10" IsVisible="{Binding IsSingleImage}">
-                            <TextBlock Text="Histogramm" FontSize="{DynamicResource FP.Font.Subtitle}" FontWeight="SemiBold"/>
-                            <Border Height="92" Background="{DynamicResource FP.Bg.Input}" CornerRadius="6" ClipToBounds="True">
-                                <Image Source="{Binding HistogramImage}"
-                                       Stretch="Fill"
-                                       RenderOptions.BitmapInterpolationMode="LowQuality"/>
-                            </Border>
+                            <StackPanel Spacing="10">
+                                <TextBlock Text="Histogramm" FontSize="{DynamicResource FP.Font.Subtitle}" FontWeight="SemiBold"/>
+                                <Border Height="92" Background="{DynamicResource FP.Bg.Input}" CornerRadius="6" ClipToBounds="True">
+                                    <Image Source="{Binding HistogramImage}"
+                                           Stretch="Fill"
+                                           RenderOptions.BitmapInterpolationMode="LowQuality"/>
+                                </Border>
+                            </StackPanel>
                         </StackPanel>
 
                         <Border Height="1" Background="{DynamicResource FP.Border.Normal}"/>

--- a/Views/ViewerView.axaml
+++ b/Views/ViewerView.axaml
@@ -674,11 +674,10 @@
 
         </Grid>
 
-        <!-- A single VideoView sits beside the filmstrip in windowed mode and
-             covers the viewer in fullscreen. ApplyVideoLayout moves it between
-             those states instead of maintaining two OpenGL contexts. The libmpv
-             render context therefore survives the transition and composes inside
-             Avalonia's visual tree.
+        <!-- Keep one Avalonia video control for both modes. ApplyVideoLayout changes
+             only its grid placement; it does not create or reparent a native child
+             window. The libmpv render context is attached through the control's
+             OpenGL lifecycle and is recreated if Avalonia recreates the context.
         -->
         <Grid Name="VideoOverlay"
               Grid.Row="1" Grid.Column="0"
@@ -689,6 +688,8 @@
             <icons:MpvVideoView Name="TheVideoView"
                              IsVisible="{Binding ShowVideoSurface}"
                              Tapped="OnVideoViewTapped"/>
+            <!-- This transparent Avalonia layer stays above the framebuffer so pointer
+                 activity and tap-to-play/pause continue through the normal viewer handlers. -->
             <Border Background="Transparent"
                     PointerMoved="OnGlobalPointerActivity"
                     PointerPressed="OnVideoInputPointerPressed"

--- a/Views/ViewerView.axaml
+++ b/Views/ViewerView.axaml
@@ -674,42 +674,40 @@
 
         </Grid>
 
-        <!-- Einziges, dauerhaft angehängtes MpvVideoView für Fenster- UND Vollbildmodus - wird per
-             Grid.Row/Column/RowSpan/ColumnSpan/Margin im Code-behind (ApplyVideoLayout) zwischen
-             beiden Zuständen umgeschaltet, statt zwei separate VideoViews mit eigenem
-             Anhängen/Abhängen-Zyklus zu verwenden. Letzteres führte dazu, dass das native
-             Fenster-Handle beim Wechsel nicht zuverlässig rechtzeitig bereitstand (kein Bild,
-             oder mpv erzeugte mangels Ziel kurzzeitig ein eigenes Fenster).
+        <!-- A single VideoView sits beside the filmstrip in windowed mode and
+             covers the viewer in fullscreen. ApplyVideoLayout moves it between
+             those states instead of maintaining two OpenGL contexts. The libmpv
+             render context therefore survives the transition and composes inside
+             Avalonia's visual tree.
         -->
         <Grid Name="VideoOverlay"
               Grid.Row="1" Grid.Column="0"
               Margin="88,0,80,0"
               Background="Black"
               ClipToBounds="True"
-              IsVisible="{Binding IsVideoFile}"
-              RowDefinitions="*,Auto">
-            <icons:MpvVideoView Name="TheVideoView" Grid.Row="0"
+              IsVisible="{Binding IsVideoFile}">
+            <icons:MpvVideoView Name="TheVideoView"
                              IsVisible="{Binding ShowVideoSurface}"
                              Tapped="OnVideoViewTapped"/>
-            <Border Grid.Row="0"
-                    Background="Transparent"
+            <Border Background="Transparent"
                     PointerMoved="OnGlobalPointerActivity"
                     PointerPressed="OnVideoInputPointerPressed"
                     Tapped="OnVideoViewTapped"/>
-            <StackPanel Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="10"
+            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="10"
                         IsVisible="{Binding ShowVideoUnavailableNotice}">
                 <icons:SvgIcon Source="avares://FerrumPix/Assets/Icons/outline/video.svg" Width="40" Height="40" HorizontalAlignment="Center" Opacity="0.6"/>
                 <TextBlock Text="Videowiedergabe nicht verfügbar" Foreground="{DynamicResource FP.Text.Muted}" FontSize="{DynamicResource FP.Font.Subtitle}" HorizontalAlignment="Center"/>
                 <TextBlock Text="mpv ist auf diesem System nicht installiert" Foreground="{DynamicResource FP.Text.Muted}" FontSize="{DynamicResource FP.Font.Small}" HorizontalAlignment="Center"/>
             </StackPanel>
             <Border Name="VideoPlaybackBar"
-                    Grid.Row="1"
+                    VerticalAlignment="Bottom"
+                    HorizontalAlignment="Stretch"
                     Background="#CC1A1D24"
                     CornerRadius="8"
                     Padding="12,8"
                     Margin="12">
                 <Grid ColumnDefinitions="Auto,*,Auto,Auto" VerticalAlignment="Center">
-                    <Button Grid.Column="0" Classes="icon-btn" Width="32" Height="32"
+                    <Button Grid.Column="0" Classes="icon-btn video-control" Width="32" Height="32"
                             Command="{Binding PlayPauseVideoCommand}"
                             ToolTip.Tip="Play/Pause">
                         <Panel>
@@ -721,15 +719,14 @@
                                        Minimum="0" Maximum="{Binding VideoDurationSeconds}"
                                        Value="{Binding VideoPositionSeconds, Mode=OneWay}"/>
                     <TextBlock Grid.Column="2" Text="{Binding VideoTimeText}" Foreground="White" FontSize="{DynamicResource FP.Font.Small}" VerticalAlignment="Center" Margin="0,0,10,0"/>
-                    <Button Grid.Column="3" Classes="icon-btn" Width="32" Height="32"
+                    <Button Grid.Column="3" Classes="icon-btn video-control" Width="32" Height="32"
                             Command="{Binding ToggleVideoMuteCommand}"
                             ToolTip.Tip="Stumm">
                         <Panel Width="16" Height="16">
-                            <icons:SvgIcon Source="avares://FerrumPix/Assets/Icons/outline/volume.svg" Width="16" Height="16" IconBrush="White"/>
+                            <icons:SvgIcon Source="avares://FerrumPix/Assets/Icons/outline/volume.svg" Width="16" Height="16"/>
                             <icons:SvgIcon Source="avares://FerrumPix/Assets/Icons/outline/x.svg"
                                            Width="9" Height="9"
                                            HorizontalAlignment="Right" VerticalAlignment="Bottom"
-                                           IconBrush="White"
                                            IsVisible="{Binding IsVideoMuted}"/>
                         </Panel>
                     </Button>

--- a/Views/ViewerView.axaml.vb
+++ b/Views/ViewerView.axaml.vb
@@ -998,8 +998,9 @@ Namespace Views
                 ResetFullscreenVideoControlsVisibility()
             End If
 
-            ' ShowVideoSurface changes at video end and again when playback restarts,
-            ' so the player must be assigned to the OpenGL control again.
+            ' These properties can change while the same control remains in the visual tree.
+            ' Re-run the assignment so MpvVideoView can attach or detach the current player
+            ' through its OpenGL lifecycle without creating a second video surface.
             If e.PropertyName = NameOf(ViewerViewModel.IsVideoFile) OrElse
                e.PropertyName = NameOf(ViewerViewModel.ShowVideoSurface) Then
                 UpdateActiveVideoView()
@@ -1103,9 +1104,10 @@ Namespace Views
             bar.IsVisible = available AndAlso visibleInMode
         End Sub
 
-        ''' Positions the single video overlay for windowed or fullscreen display.
-        ''' Layout changes move the same control without detaching it, preserving
-        ''' the OpenGL context across fullscreen transitions.
+        ''' Moves the single video overlay between windowed and fullscreen layout.
+        ''' The control remains in the visual tree, so fullscreen changes do not require
+        ''' a second player or a platform-native window; OpenGL lifecycle callbacks handle
+        ''' any context recreation performed by Avalonia.
         Private Sub ApplyVideoLayout()
             Dim vm = GetVm()
             Dim overlay = Me.FindControl(Of Grid)("VideoOverlay")
@@ -1127,8 +1129,8 @@ Namespace Views
         End Sub
 
         ''' Assigns the ViewerViewModel player to the single video overlay, or clears it,
-        ''' when the active media changes. Fullscreen transitions only move the overlay,
-        ''' allowing the OpenGL context to survive fullscreen and video navigation.
+        ''' when the active media changes. Fullscreen transitions only move the overlay;
+        ''' changing media swaps the player while the same OpenGL control is retained.
         Private _pendingVideoAttachHandler As EventHandler
 
         Private Sub UpdateActiveVideoView()
@@ -1150,9 +1152,9 @@ Namespace Views
             AttachVideoPlayer(videoView, vm.VideoMediaPlayer, vm)
         End Sub
 
-        ''' The OpenGL renderer is created after the first layout pass. Assign the
-        ''' player only once the control has a real size so libmpv receives a valid
-        ''' framebuffer from the first frame.
+        ''' Defer assignment until the control has non-zero layout bounds. MpvVideoView
+        ''' attaches libmpv from its OpenGL callbacks, and a zero-sized control cannot
+        ''' provide a useful framebuffer for the first frame.
         Private Sub AttachVideoPlayer(target As MpvVideoView, mediaPlayer As MpvPlayer, vm As ViewerViewModel)
             If target.Bounds.Width > 0 AndAlso target.Bounds.Height > 0 Then
                 target.Player = mediaPlayer
@@ -1174,6 +1176,8 @@ Namespace Views
 
         Private Async Sub StartPendingVideoAutoplayAfterHostReady(target As MpvVideoView, mediaPlayer As MpvPlayer, vm As ViewerViewModel)
             Try
+                ' Let the first layout/OpenGL pass settle before autoplay. The identity
+                ' checks below prevent this delayed callback from starting stale media.
                 Await Task.Delay(180)
                 If target Is Nothing OrElse vm Is Nothing Then Return
                 If Not Object.ReferenceEquals(target.Player, mediaPlayer) Then Return

--- a/Views/ViewerView.axaml.vb
+++ b/Views/ViewerView.axaml.vb
@@ -998,8 +998,8 @@ Namespace Views
                 ResetFullscreenVideoControlsVisibility()
             End If
 
-            ' ShowVideoSurface kippt beim Videoende (Fläche verschwindet) und beim erneuten Abspielen
-            ' (Fläche kommt zurück) - im zweiten Fall muss der Player an das neu erzeugte native Fenster.
+            ' ShowVideoSurface changes at video end and again when playback restarts,
+            ' so the player must be assigned to the OpenGL control again.
             If e.PropertyName = NameOf(ViewerViewModel.IsVideoFile) OrElse
                e.PropertyName = NameOf(ViewerViewModel.ShowVideoSurface) Then
                 UpdateActiveVideoView()
@@ -1103,11 +1103,9 @@ Namespace Views
             bar.IsVisible = available AndAlso visibleInMode
         End Sub
 
-        ''' Positioniert das einzige VideoOverlay-Grid je nach Vollbild-Status: im Fenstermodus
-        ''' auf die Content-Zelle (Grid.Row=1/Column=0) mit demselben 88/0/80/0-Rand wie das
-        ''' Bild, im Vollbildmodus über das gesamte Fenster (RowSpan=3/ColumnSpan=2, randlos) -
-        ''' rein per Layout, ohne das VideoView selbst je ab- und wieder anzuhängen. Dadurch
-        ''' bleibt sein natives Fenster-Handle über Vollbild-Wechsel hinweg unangetastet.
+        ''' Positions the single video overlay for windowed or fullscreen display.
+        ''' Layout changes move the same control without detaching it, preserving
+        ''' the OpenGL context across fullscreen transitions.
         Private Sub ApplyVideoLayout()
             Dim vm = GetVm()
             Dim overlay = Me.FindControl(Of Grid)("VideoOverlay")
@@ -1128,10 +1126,9 @@ Namespace Views
             End If
         End Sub
 
-        ''' Weist den von ViewerViewModel gehaltenen MediaPlayer dem einzigen VideoOverlay zu
-        ''' (bzw. leert es), wenn sich IsVideoFile ändert - der Vollbild-Wechsel selbst löst dies
-        ''' NICHT mehr aus (siehe ApplyVideoLayout), wodurch das native Fenster-Handle über
-        ''' Vollbild-Wechsel und Video-zu-Video-Navigation hinweg bestehen bleibt.
+        ''' Assigns the ViewerViewModel player to the single video overlay, or clears it,
+        ''' when the active media changes. Fullscreen transitions only move the overlay,
+        ''' allowing the OpenGL context to survive fullscreen and video navigation.
         Private _pendingVideoAttachHandler As EventHandler
 
         Private Sub UpdateActiveVideoView()
@@ -1153,13 +1150,9 @@ Namespace Views
             AttachVideoPlayer(videoView, vm.VideoMediaPlayer, vm)
         End Sub
 
-        ''' Das native Fenster-Handle eines MpvVideoView-Controls entsteht erst, sobald für es
-        ''' tatsächlich ein Layout-Durchlauf stattgefunden hat (insbesondere direkt nachdem sein
-        ''' Container durch einen Sichtbarkeits-Wechsel gerade erst sichtbar wurde). MediaPlayer
-        ''' vorher zuzuweisen kann "ins Leere" binden (Ton läuft weiter, kein Bild) oder mpv
-        ''' dazu bringen, mangels Ausgabeziel kurz ein eigenes Fenster zu erzeugen. Statt einer
-        ''' geschätzten Dispatcher-Verzögerung wird hier direkt auf LayoutUpdated gewartet, bis
-        ''' das Control tatsächlich eine reale Größe hat.
+        ''' The OpenGL renderer is created after the first layout pass. Assign the
+        ''' player only once the control has a real size so libmpv receives a valid
+        ''' framebuffer from the first frame.
         Private Sub AttachVideoPlayer(target As MpvVideoView, mediaPlayer As MpvPlayer, vm As ViewerViewModel)
             If target.Bounds.Width > 0 AndAlso target.Bounds.Height > 0 Then
                 target.Player = mediaPlayer


### PR DESCRIPTION
## Summary

- render libmpv frames through Avalonia's OpenGL control instead of a platform-native child window
- serialize libmpv commands away from the UI and render callbacks
- keep one Avalonia video control across fullscreen transitions and video navigation, while reattaching libmpv if Avalonia recreates the OpenGL context
- synchronize playback state immediately and keep video controls readable over the frame
- hide image-only histogram content while viewing video
- discover system-installed libmpv in conventional Homebrew, Intel Homebrew, and MacPorts locations on macOS

## Motivation

The previous native child-window approach used platform window handles and did not compose reliably with Avalonia layout and overlays on macOS. In failure cases, the embedded surface could remain black while mpv opened a separate window.

This change uses the libmpv Render API with an Avalonia OpenGL control. Avalonia owns the framebuffer, clipping, controls, and fullscreen layout, while libmpv commands are kept away from the UI thread and OpenGL render callbacks. The same rendering and composition path is now used on Windows, Linux, and macOS.

macOS also has a separate library-discovery issue. A Homebrew-installed libmpv normally lives under `/opt/homebrew`, which is not necessarily searched by the .NET native-library resolver when FerrumPix is launched as an application bundle. The resolver now checks the default library names first, then conventional Homebrew, Intel Homebrew, and MacPorts library directories before retaining the existing application-local fallback.

## Dependency policy

This PR does not bundle libmpv or codecs and does not add package references or packaging changes. It preserves the existing system-first policy. On macOS, libmpv must still be installed separately, for example with:

```sh
brew install mpv
```

## Validation

- user-level testing completed on a Mac mini with an M4 chip and Homebrew mpv
- video frames render inside the FerrumPix window without a separate mpv window
- playback, pause, resume, seeking, fullscreen entry and exit, returning to the gallery, and application exit were verified
- Windows and Linux now use the same Avalonia OpenGL composition path; build and runtime validation on both platforms is still required before cross-platform behavior can be considered verified
