### PR TITLE
Decode HEIF images with ImageIO on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Lens defects are corrected from measured data: distortion, the coloured fringes 
 
 Edits to a RAW go into a small `.fpxmp` sidecar next to it; the RAW itself is never modified, and the sidecar travels with the file when you move, copy or rename it in FerrumPix. A Lightroom `.xmp` sidecar with develop settings is converted once, so a photo edited elsewhere opens the way you left it.
 
-Photoshop (`.psd`/`.psb`), HEIC/HEIF/AVIF and TIFF open read-only - *Save as…* writes them out in one of the normal formats. HEIC needs the system's `libheif`; TIFF needs nothing extra.
+Photoshop (`.psd`/`.psb`), HEIC/HEIF/AVIF and TIFF open read-only - *Save as…* writes them out in one of the normal formats. HEIC needs the system's `libheif`, except on macOS, which reads it itself; TIFF needs nothing extra.
 
 ### Model files
 
@@ -142,7 +142,7 @@ On macOS the window carries the usual title bar with the red, yellow and green b
 
 `libmpv` (video) and `libraw` (RAW development) are required rather than optional. The Linux packages declare both as dependencies; the Windows releases bundle them. The Flatpak builds LibRaw in but ships no `libmpv`, so it has no video support, and the macOS builds need `brew install libraw`. Where a library is present on the system, FerrumPix prefers it over a bundled copy, so it keeps getting updates and support for newer cameras.
 
-`libheif` is optional and never bundled, on any platform: it opens HEIC/HEIF/AVIF, and those are usually HEVC-encoded, which carries patent licensing in several countries - a decision for your distribution rather than for this project. Without it, HEIC files simply stay closed and everything else works.
+`libheif` is optional and never bundled, on any platform: it opens HEIC/HEIF/AVIF, and those are usually HEVC-encoded, which carries patent licensing in several countries - a decision for your distribution rather than for this project. Without it, HEIC files simply stay closed and everything else works. macOS is the exception: it reads these formats itself, so nothing has to be installed there.
 
 ## Building from source
 

--- a/Services/HeifDecodeService.vb
+++ b/Services/HeifDecodeService.vb
@@ -1,30 +1,28 @@
 Imports System
 Imports System.IO
+Imports System.Linq
 Imports System.Runtime.InteropServices
 Imports SkiaSharp
 
 Namespace Services
 
     ''' <summary>
-    ''' Liest HEIC/HEIF (und AVIF, sofern die Bibliothek den Codec mitbringt) über libheif -
-    ''' SkiaSharp kann beides nicht. Damit lassen sich iPhone-Fotos direkt ansehen und bearbeiten,
-    ''' statt sie vorher umwandeln zu müssen; geschrieben wird HEIC bewusst NICHT (siehe unten).
+    ''' Reads HEIC/HEIF and AVIF without teaching callers which platform decoder is available.
+    ''' macOS uses the built-in ImageIO frameworks. Other platforms retain the optional system
+    ''' libheif loader, so FerrumPix does not distribute an HEVC decoder or change codec policy.
     '''
-    ''' Geladen wird dynamisch über NativeLibrary.Load + Delegates, genau wie bei LibRaw: der
-    ''' DllImport-Resolver der Assembly ist bereits belegt (nur EINER erlaubt), und so bleibt die
-    ''' Verfügbarkeit sauber prüfbar. Fehlt libheif, meldet IsAvailable False und ALLES läuft wie
-    ''' bisher - HEIC-Dateien erscheinen dann einfach nicht als Bild, kein Absturz.
+    ''' The non-macOS backend loads libheif dynamically through NativeLibrary and delegates. The
+    ''' assembly already has a DllImport resolver, and only one can be registered, while explicit
+    ''' loading also keeps decoder availability testable and optional.
     '''
-    ''' NUR die Bibliothek des SYSTEMS, bewusst ohne mitgelieferten Rückfall (anders als LibRaw):
-    ''' HEIC-Dateien sind in aller Regel HEVC-kodiert, und für HEVC bestehen Patentansprüche.
-    ''' Die Entscheidung, einen HEVC-Dekoder auszuliefern, trifft damit die Distribution
-    ''' (Arch/Debian/Fedora liefern libheif+libde265 in ihren Paketquellen), nicht FerrumPix.
-    ''' Lizenzseitig ist alles unkritisch: libheif und libde265 stehen unter der LGPL-3 und werden
-    ''' unverändert dynamisch geladen - dieselbe Konstruktion wie bei LibRaw und libmpv.
+    ''' Only the system libheif is considered; there is deliberately no bundled fallback. HEIF
+    ''' images commonly use HEVC, so the decision to provide an HEVC decoder remains with the
+    ''' operating system or distribution rather than FerrumPix. The library is used unmodified
+    ''' and dynamically, following the same replaceable-system-library model as LibRaw and libmpv.
     '''
-    ''' NUR LESEN: einen Encoder gibt es hier nicht. Bearbeitete HEIC-Dateien werden wie PSD als
-    ''' neue Datei in einem schreibbaren Format gespeichert (ImageProcessor.CanEncodeToTargetExtension
-    ''' weist ein HEIC-Ziel ab), damit keine Datei still unter falscher Endung landet.
+    ''' This module is intentionally read-only. Edited HEIF files are saved to an encodable format
+    ''' instead of writing different data under the original extension. ImageProcessor rejects a
+    ''' HEIF target so an edited image can never be silently written with mismatched file contents.
     ''' </summary>
     Public NotInheritable Class HeifDecodeService
 
@@ -81,17 +79,21 @@ Namespace Services
         Private Shared _handleRelease As ReleaseFn
         Private Shared _imageRelease As ReleaseFn
 
-        ''' <summary>True, wenn libheif geladen werden konnte (Ergebnis wird gecacht).</summary>
+        ''' <summary>True when the platform ImageIO or optional libheif decoder is available.</summary>
         Public Shared ReadOnly Property IsAvailable As Boolean
             Get
+                If OperatingSystem.IsMacOS() Then
+                    Return CoreFoundationHandle <> IntPtr.Zero AndAlso ImageIoHandle <> IntPtr.Zero
+                End If
                 EnsureLoaded()
                 Return _library <> IntPtr.Zero
             End Get
         End Property
 
-        ''' <summary>Welche libheif-Variante geladen wurde - für die Diagnose und Feldberichte.</summary>
+        ''' <summary>The active platform decoder name, for diagnostics and field reports.</summary>
         Public Shared ReadOnly Property LoadedLibraryName As String
             Get
+                If OperatingSystem.IsMacOS() AndAlso IsAvailable Then Return "ImageIO"
                 EnsureLoaded()
                 Return If(_loadedLibrary, "")
             End Get
@@ -165,12 +167,17 @@ Namespace Services
             Return Marshal.GetDelegateForFunctionPointer(Of T)(NativeLibrary.GetExport(handle, name))
         End Function
 
-        ''' <summary>Dekodiert die Hauptaufnahme der Datei als Bgra8888 (Besitz beim Aufrufer) oder
-        ''' Nothing. Drehung/Spiegelung aus dem Container wendet libheif selbst an (die
-        ''' Standard-Dekodieroptionen lassen Transformationen nicht aus) - es braucht also KEINE
-        ''' zusätzliche Orientierungskorrektur, anders als beim eingebetteten RAW-Vorschaubild.</summary>
+        ''' <summary>Decodes the oriented primary image as caller-owned Bgra8888 pixels.
+        ''' ImageIO applies the container transform through kCGImageSourceCreateThumbnailWithTransform;
+        ''' libheif applies the container transformations through its default decoding options.
+        ''' Callers must therefore not apply an additional orientation correction.</summary>
         Public Shared Function TryDecode(path As String) As SKBitmap
             If String.IsNullOrWhiteSpace(path) OrElse Not IsAvailable Then Return Nothing
+            If OperatingSystem.IsMacOS() Then
+                Using preview = ExtractWithMacImageIo(path)
+                    Return If(preview IsNot Nothing, SKBitmap.Decode(preview), Nothing)
+                End Using
+            End If
             SyncLock _nativeLock
                 Return DecodeCore(path)
             End SyncLock
@@ -242,6 +249,9 @@ Namespace Services
         ''' <summary>Die Datei als PNG-Strom - das ist die Form, die OpenSourceStream und die
         ''' Thumbnail-Erzeugung erwarten (gleiches Muster wie PSD/ICO).</summary>
         Public Shared Function ExtractPreview(path As String) As MemoryStream
+            If String.IsNullOrWhiteSpace(path) OrElse Not IsAvailable Then Return Nothing
+            If OperatingSystem.IsMacOS() Then Return ExtractWithMacImageIo(path)
+
             Using bmp = TryDecode(path)
                 If bmp Is Nothing Then Return Nothing
                 Using image = SKImage.FromBitmap(bmp)
@@ -260,6 +270,8 @@ Namespace Services
         ''' <summary>Maße ohne vollständiges Dekodieren - die Kopfdaten reichen dafür.</summary>
         Public Shared Function TryGetSize(path As String) As (Width As Integer, Height As Integer)
             If String.IsNullOrWhiteSpace(path) OrElse Not IsAvailable Then Return (0, 0)
+            If OperatingSystem.IsMacOS() Then Return TryGetSizeWithMacImageIo(path)
+
             SyncLock _nativeLock
                 Dim ctx As IntPtr = IntPtr.Zero
                 Dim handle As IntPtr = IntPtr.Zero
@@ -281,12 +293,257 @@ Namespace Services
             End SyncLock
         End Function
 
+        Private Shared Function TryGetSizeWithMacImageIo(path As String) As (Width As Integer, Height As Integer)
+            Dim url As IntPtr = IntPtr.Zero
+            Dim source As IntPtr = IntPtr.Zero
+            Dim properties As IntPtr = IntPtr.Zero
+            Try
+                url = CreateFileUrl(path)
+                If url = IntPtr.Zero Then Return (0, 0)
+                source = CGImageSourceCreateWithURL(url, IntPtr.Zero)
+                If source = IntPtr.Zero Then Return (0, 0)
+                properties = CGImageSourceCopyPropertiesAtIndex(source, UIntPtr.Zero, IntPtr.Zero)
+                If properties = IntPtr.Zero Then Return (0, 0)
+
+                Dim width = ReadDictionaryInteger(
+                    properties, ReadFrameworkConstant(ImageIoHandle, "kCGImagePropertyPixelWidth"))
+                Dim height = ReadDictionaryInteger(
+                    properties, ReadFrameworkConstant(ImageIoHandle, "kCGImagePropertyPixelHeight"))
+                Dim orientation = ReadDictionaryInteger(
+                    properties, ReadFrameworkConstant(ImageIoHandle, "kCGImagePropertyOrientation"))
+                If orientation >= 5 AndAlso orientation <= 8 Then
+                    Dim swap = width
+                    width = height
+                    height = swap
+                End If
+                Return (width, height)
+            Catch
+                Return (0, 0)
+            Finally
+                Release(properties)
+                Release(source)
+                Release(url)
+            End Try
+        End Function
+
+        Private Shared Function ExtractWithMacImageIo(path As String) As MemoryStream
+            Dim url As IntPtr = IntPtr.Zero
+            Dim source As IntPtr = IntPtr.Zero
+            Dim options As IntPtr = IntPtr.Zero
+            Dim maxPixelNumber As IntPtr = IntPtr.Zero
+            Dim image As IntPtr = IntPtr.Zero
+            Dim data As IntPtr = IntPtr.Zero
+            Dim pngType As IntPtr = IntPtr.Zero
+            Dim destination As IntPtr = IntPtr.Zero
+
+            Try
+                url = CreateFileUrl(path)
+                If url = IntPtr.Zero Then Return Nothing
+                source = CGImageSourceCreateWithURL(url, IntPtr.Zero)
+                If source = IntPtr.Zero Then Return Nothing
+
+                Dim maximum = Integer.MaxValue
+                maxPixelNumber = CFNumberCreate(IntPtr.Zero, CFNumberSInt32Type, maximum)
+                If maxPixelNumber = IntPtr.Zero Then Return Nothing
+
+                Dim keys = {
+                    ReadFrameworkConstant(ImageIoHandle, "kCGImageSourceCreateThumbnailFromImageAlways"),
+                    ReadFrameworkConstant(ImageIoHandle, "kCGImageSourceCreateThumbnailWithTransform"),
+                    ReadFrameworkConstant(ImageIoHandle, "kCGImageSourceThumbnailMaxPixelSize")
+                }
+                Dim values = {
+                    ReadFrameworkConstant(CoreFoundationHandle, "kCFBooleanTrue"),
+                    ReadFrameworkConstant(CoreFoundationHandle, "kCFBooleanTrue"),
+                    maxPixelNumber
+                }
+                If keys.Any(Function(value) value = IntPtr.Zero) OrElse
+                   values.Any(Function(value) value = IntPtr.Zero) Then Return Nothing
+
+                options = CFDictionaryCreate(
+                    IntPtr.Zero, keys, values, CType(keys.Length, UIntPtr), IntPtr.Zero, IntPtr.Zero)
+                If options = IntPtr.Zero Then Return Nothing
+                image = CGImageSourceCreateThumbnailAtIndex(source, UIntPtr.Zero, options)
+                If image = IntPtr.Zero Then Return Nothing
+
+                data = CFDataCreateMutable(IntPtr.Zero, UIntPtr.Zero)
+                pngType = CFStringCreateWithCString(IntPtr.Zero, "public.png", CFStringEncodingUtf8)
+                If data = IntPtr.Zero OrElse pngType = IntPtr.Zero Then Return Nothing
+                destination = CGImageDestinationCreateWithData(data, pngType, CType(1, UIntPtr), IntPtr.Zero)
+                If destination = IntPtr.Zero Then Return Nothing
+
+                CGImageDestinationAddImage(destination, image, IntPtr.Zero)
+                If CGImageDestinationFinalize(destination) = 0 Then Return Nothing
+
+                Dim length = CFDataGetLength(data)
+                Dim bytesPointer = CFDataGetBytePtr(data)
+                If length <= 0 OrElse bytesPointer = IntPtr.Zero OrElse length > Integer.MaxValue Then Return Nothing
+
+                Dim bytes(CInt(length) - 1) As Byte
+                Marshal.Copy(bytesPointer, bytes, 0, bytes.Length)
+                Return New MemoryStream(bytes, writable:=False)
+            Catch
+                Return Nothing
+            Finally
+                Release(destination)
+                Release(pngType)
+                Release(data)
+                Release(image)
+                Release(options)
+                Release(maxPixelNumber)
+                Release(source)
+                Release(url)
+            End Try
+        End Function
+
+        Private Shared Function CreateFileUrl(path As String) As IntPtr
+            Dim pathBytes = Text.Encoding.UTF8.GetBytes(path)
+            Return CFURLCreateFromFileSystemRepresentation(
+                IntPtr.Zero, pathBytes, CType(pathBytes.Length, UIntPtr), False)
+        End Function
+
+        Private Shared Function ReadDictionaryInteger(dictionary As IntPtr, key As IntPtr) As Integer
+            If dictionary = IntPtr.Zero OrElse key = IntPtr.Zero Then Return 0
+            Dim number = CFDictionaryGetValue(dictionary, key)
+            If number = IntPtr.Zero Then Return 0
+            Dim value As Integer
+            Return If(CFNumberGetValue(number, CFNumberSInt32Type, value) <> 0, value, 0)
+        End Function
+
+        Private Shared Function ReadFrameworkConstant(handle As IntPtr, name As String) As IntPtr
+            If handle = IntPtr.Zero Then Return IntPtr.Zero
+            Dim symbol As IntPtr
+            If Not NativeLibrary.TryGetExport(handle, name, symbol) Then Return IntPtr.Zero
+            Return Marshal.ReadIntPtr(symbol)
+        End Function
+
+        Private Shared Function LoadFrameworkIfAvailable(path As String) As IntPtr
+            If Not OperatingSystem.IsMacOS() Then Return IntPtr.Zero
+            Try
+                Return NativeLibrary.Load(path)
+            Catch
+                Return IntPtr.Zero
+            End Try
+        End Function
+
+        Private Shared Sub Release(value As IntPtr)
+            If value <> IntPtr.Zero Then CFRelease(value)
+        End Sub
+
         Private Shared Function StringToUtf8(value As String) As IntPtr
             Dim bytes = Text.Encoding.UTF8.GetBytes(value)
             Dim ptr = Marshal.AllocCoTaskMem(bytes.Length + 1)
             Marshal.Copy(bytes, 0, ptr, bytes.Length)
             Marshal.WriteByte(ptr, bytes.Length, 0)
             Return ptr
+        End Function
+
+        Private Const CoreFoundationFramework As String =
+            "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+        Private Const ImageIoFramework As String =
+            "/System/Library/Frameworks/ImageIO.framework/ImageIO"
+        Private Shared ReadOnly CoreFoundationHandle As IntPtr =
+            LoadFrameworkIfAvailable(CoreFoundationFramework)
+        Private Shared ReadOnly ImageIoHandle As IntPtr =
+            LoadFrameworkIfAvailable(ImageIoFramework)
+        Private Const CFNumberSInt32Type As Integer = 3
+        Private Const CFStringEncodingUtf8 As UInteger = &H8000100UI
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFURLCreateFromFileSystemRepresentation(
+            allocator As IntPtr,
+            buffer As Byte(),
+            bufferLength As UIntPtr,
+            <MarshalAs(UnmanagedType.I1)> isDirectory As Boolean) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFNumberCreate(
+            allocator As IntPtr,
+            numberType As Integer,
+            ByRef value As Integer) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDictionaryCreate(
+            allocator As IntPtr,
+            keys As IntPtr(),
+            values As IntPtr(),
+            count As UIntPtr,
+            keyCallbacks As IntPtr,
+            valueCallbacks As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDictionaryGetValue(dictionary As IntPtr, key As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFNumberGetValue(
+            number As IntPtr,
+            numberType As Integer,
+            ByRef value As Integer) As Integer
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDataCreateMutable(
+            allocator As IntPtr,
+            capacity As UIntPtr) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFStringCreateWithCString(
+            allocator As IntPtr,
+            value As String,
+            encoding As UInteger) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDataGetLength(data As IntPtr) As Long
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDataGetBytePtr(data As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Sub CFRelease(value As IntPtr)
+        End Sub
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageSourceCreateWithURL(url As IntPtr, options As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageSourceCopyPropertiesAtIndex(
+            source As IntPtr,
+            index As UIntPtr,
+            options As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageSourceCreateThumbnailAtIndex(
+            source As IntPtr,
+            index As UIntPtr,
+            options As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageDestinationCreateWithData(
+            data As IntPtr,
+            type As IntPtr,
+            count As UIntPtr,
+            options As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Sub CGImageDestinationAddImage(
+            destination As IntPtr,
+            image As IntPtr,
+            properties As IntPtr)
+        End Sub
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageDestinationFinalize(destination As IntPtr) As Integer
         End Function
 
     End Class

--- a/Services/HeifDecodeService.vb
+++ b/Services/HeifDecodeService.vb
@@ -1,28 +1,38 @@
 Imports System
 Imports System.IO
-Imports System.Linq
 Imports System.Runtime.InteropServices
 Imports SkiaSharp
 
 Namespace Services
 
     ''' <summary>
-    ''' Reads HEIC/HEIF and AVIF without teaching callers which platform decoder is available.
-    ''' macOS uses the built-in ImageIO frameworks. Other platforms retain the optional system
-    ''' libheif loader, so FerrumPix does not distribute an HEVC decoder or change codec policy.
+    ''' Liest HEIC/HEIF (und AVIF, sofern die Bibliothek den Codec mitbringt) über libheif -
+    ''' SkiaSharp kann beides nicht. Damit lassen sich iPhone-Fotos direkt ansehen und bearbeiten,
+    ''' statt sie vorher umwandeln zu müssen; geschrieben wird HEIC bewusst NICHT (siehe unten).
     '''
-    ''' The non-macOS backend loads libheif dynamically through NativeLibrary and delegates. The
-    ''' assembly already has a DllImport resolver, and only one can be registered, while explicit
-    ''' loading also keeps decoder availability testable and optional.
+    ''' Auf macOS bringt das Betriebssystem den Dekoder selbst mit, dort ist HEIC das Standardformat
+    ''' der Kamera und ein extra installiertes libheif die Ausnahme. Diesen Weg kapselt
+    ''' MacImageIoService; findet er sich, läuft ALLES darüber. Die Klasse hier fragt dafür nur
+    ''' MacImageIoService.IsAvailable und kennt weder das Betriebssystem noch dessen Schnittstellen.
+    ''' Meldet der Dienst False - auf Linux und Windows immer -, bleibt es beim libheif-Weg unten,
+    ''' und für diese beiden Systeme ändert sich damit nichts.
     '''
-    ''' Only the system libheif is considered; there is deliberately no bundled fallback. HEIF
-    ''' images commonly use HEVC, so the decision to provide an HEVC decoder remains with the
-    ''' operating system or distribution rather than FerrumPix. The library is used unmodified
-    ''' and dynamically, following the same replaceable-system-library model as LibRaw and libmpv.
+    ''' Geladen wird dynamisch über NativeLibrary.Load + Delegates, genau wie bei LibRaw: der
+    ''' DllImport-Resolver der Assembly ist bereits belegt (nur EINER erlaubt), und so bleibt die
+    ''' Verfügbarkeit sauber prüfbar. Fehlt libheif, meldet IsAvailable False und ALLES läuft wie
+    ''' bisher - HEIC-Dateien erscheinen dann einfach nicht als Bild, kein Absturz.
     '''
-    ''' This module is intentionally read-only. Edited HEIF files are saved to an encodable format
-    ''' instead of writing different data under the original extension. ImageProcessor rejects a
-    ''' HEIF target so an edited image can never be silently written with mismatched file contents.
+    ''' NUR die Bibliothek des SYSTEMS, bewusst ohne mitgelieferten Rückfall (anders als LibRaw):
+    ''' HEIC-Dateien sind in aller Regel HEVC-kodiert, und für HEVC bestehen Patentansprüche.
+    ''' Die Entscheidung, einen HEVC-Dekoder auszuliefern, trifft damit die Distribution
+    ''' (Arch/Debian/Fedora liefern libheif+libde265 in ihren Paketquellen), nicht FerrumPix.
+    ''' Lizenzseitig ist alles unkritisch: libheif und libde265 stehen unter der LGPL-3 und werden
+    ''' unverändert dynamisch geladen - dieselbe Konstruktion wie bei LibRaw und libmpv. Auch der
+    ''' macOS-Weg ändert daran nichts: ImageIO gehört zum Betriebssystem und wird nicht mitgeliefert.
+    '''
+    ''' NUR LESEN: einen Encoder gibt es hier nicht. Bearbeitete HEIC-Dateien werden wie PSD als
+    ''' neue Datei in einem schreibbaren Format gespeichert (ImageProcessor.CanEncodeToTargetExtension
+    ''' weist ein HEIC-Ziel ab), damit keine Datei still unter falscher Endung landet.
     ''' </summary>
     Public NotInheritable Class HeifDecodeService
 
@@ -59,7 +69,9 @@ Namespace Services
         ''' libheif ist nicht garantiert reentrant über einen Kontext hinweg; jeder Aufruf legt
         ''' zwar seinen eigenen Kontext an, die Thumbnail-Erzeugung ruft aber aus mehreren Threads
         ''' herein. Wie bei der nicht-reentranten LibRaw wird deshalb serialisiert - lieber
-        ''' langsamere Thumbnails als sporadische Abstürze.
+        ''' langsamere Thumbnails als sporadische Abstürze. Der Weg über das Betriebssystem
+        ''' liegt bewusst unter demselben Schloss: ImageIO wäre zwar threadsicher, aber in der
+        ''' ganzen Anwendung soll immer nur EIN Decode gleichzeitig laufen.
         Private Shared ReadOnly _nativeLock As New Object()
 
         Private Shared _initialized As Boolean
@@ -79,21 +91,22 @@ Namespace Services
         Private Shared _handleRelease As ReleaseFn
         Private Shared _imageRelease As ReleaseFn
 
-        ''' <summary>True when the platform ImageIO or optional libheif decoder is available.</summary>
+        ''' <summary>True, wenn irgendein Dekoder bereitsteht: der des Betriebssystems oder libheif
+        ''' (Ergebnis wird gecacht). Die Reihenfolge ist Absicht - liegt auf einem Mac zusätzlich
+        ''' ein libheif aus Homebrew, bleibt trotzdem der Weg des Systems der erste, und fehlen
+        ''' dort die Frameworks, greift libheif als Rückfall.</summary>
         Public Shared ReadOnly Property IsAvailable As Boolean
             Get
-                If OperatingSystem.IsMacOS() Then
-                    Return CoreFoundationHandle <> IntPtr.Zero AndAlso ImageIoHandle <> IntPtr.Zero
-                End If
+                If MacImageIoService.IsAvailable Then Return True
                 EnsureLoaded()
                 Return _library <> IntPtr.Zero
             End Get
         End Property
 
-        ''' <summary>The active platform decoder name, for diagnostics and field reports.</summary>
+        ''' <summary>Welcher Dekoder geladen wurde - für die Diagnose und Feldberichte.</summary>
         Public Shared ReadOnly Property LoadedLibraryName As String
             Get
-                If OperatingSystem.IsMacOS() AndAlso IsAvailable Then Return "ImageIO"
+                If MacImageIoService.IsAvailable Then Return MacImageIoService.DecoderName
                 EnsureLoaded()
                 Return If(_loadedLibrary, "")
             End Get
@@ -167,20 +180,45 @@ Namespace Services
             Return Marshal.GetDelegateForFunctionPointer(Of T)(NativeLibrary.GetExport(handle, name))
         End Function
 
-        ''' <summary>Decodes the oriented primary image as caller-owned Bgra8888 pixels.
-        ''' ImageIO applies the container transform through kCGImageSourceCreateThumbnailWithTransform;
-        ''' libheif applies the container transformations through its default decoding options.
-        ''' Callers must therefore not apply an additional orientation correction.</summary>
+        ''' <summary>Dekodiert die Hauptaufnahme der Datei als Bgra8888 (Besitz beim Aufrufer) oder
+        ''' Nothing. Drehung/Spiegelung aus dem Container wenden beide Wege selbst an (libheif über
+        ''' seine Standard-Dekodieroptionen, ImageIO über kCGImageSourceCreateThumbnailWithTransform)
+        ''' - es braucht also KEINE zusätzliche Orientierungskorrektur, anders als beim eingebetteten
+        ''' RAW-Vorschaubild.</summary>
         Public Shared Function TryDecode(path As String) As SKBitmap
             If String.IsNullOrWhiteSpace(path) OrElse Not IsAvailable Then Return Nothing
-            If OperatingSystem.IsMacOS() Then
-                Using preview = ExtractWithMacImageIo(path)
-                    Return If(preview IsNot Nothing, SKBitmap.Decode(preview), Nothing)
-                End Using
+            If MacImageIoService.IsAvailable Then
+                SyncLock _nativeLock
+                    Using preview = MacImageIoService.TryExtractPng(path)
+                        Return If(preview IsNot Nothing, DecodeToBgra(preview), Nothing)
+                    End Using
+                End SyncLock
             End If
             SyncLock _nativeLock
                 Return DecodeCore(path)
             End SyncLock
+        End Function
+
+        ''' <summary>Einen PNG-Strom in genau das Format bringen, das der libheif-Weg liefert.
+        ''' Ohne die feste SKImageInfo entschiede Skia selbst, und die Zusage "Bgra8888" oben
+        ''' gälte je nach Plattform - ein Fehler, den man erst an vertauschten Farben sähe.</summary>
+        Private Shared Function DecodeToBgra(stream As Stream) As SKBitmap
+            Using data = SKData.Create(stream)
+                If data Is Nothing Then Return Nothing
+                Using codec = SKCodec.Create(data)
+                    If codec Is Nothing Then Return Nothing
+                    Dim info = New SKImageInfo(codec.Info.Width, codec.Info.Height,
+                                               SKColorType.Bgra8888, SKAlphaType.Unpremul)
+                    If info.Width <= 0 OrElse info.Height <= 0 Then Return Nothing
+                    Dim bitmap = New SKBitmap(info)
+                    Dim result = codec.GetPixels(info, bitmap.GetPixels())
+                    If result <> SKCodecResult.Success AndAlso result <> SKCodecResult.IncompleteInput Then
+                        bitmap.Dispose()
+                        Return Nothing
+                    End If
+                    Return bitmap
+                End Using
+            End Using
         End Function
 
         Private Shared Function DecodeCore(path As String) As SKBitmap
@@ -250,7 +288,12 @@ Namespace Services
         ''' Thumbnail-Erzeugung erwarten (gleiches Muster wie PSD/ICO).</summary>
         Public Shared Function ExtractPreview(path As String) As MemoryStream
             If String.IsNullOrWhiteSpace(path) OrElse Not IsAvailable Then Return Nothing
-            If OperatingSystem.IsMacOS() Then Return ExtractWithMacImageIo(path)
+            ' Der Weg des Systems liefert den PNG-Strom direkt, ohne den Umweg über ein SKBitmap.
+            If MacImageIoService.IsAvailable Then
+                SyncLock _nativeLock
+                    Return MacImageIoService.TryExtractPng(path)
+                End SyncLock
+            End If
 
             Using bmp = TryDecode(path)
                 If bmp Is Nothing Then Return Nothing
@@ -270,7 +313,11 @@ Namespace Services
         ''' <summary>Maße ohne vollständiges Dekodieren - die Kopfdaten reichen dafür.</summary>
         Public Shared Function TryGetSize(path As String) As (Width As Integer, Height As Integer)
             If String.IsNullOrWhiteSpace(path) OrElse Not IsAvailable Then Return (0, 0)
-            If OperatingSystem.IsMacOS() Then Return TryGetSizeWithMacImageIo(path)
+            If MacImageIoService.IsAvailable Then
+                SyncLock _nativeLock
+                    Return MacImageIoService.TryGetSize(path)
+                End SyncLock
+            End If
 
             SyncLock _nativeLock
                 Dim ctx As IntPtr = IntPtr.Zero
@@ -293,257 +340,12 @@ Namespace Services
             End SyncLock
         End Function
 
-        Private Shared Function TryGetSizeWithMacImageIo(path As String) As (Width As Integer, Height As Integer)
-            Dim url As IntPtr = IntPtr.Zero
-            Dim source As IntPtr = IntPtr.Zero
-            Dim properties As IntPtr = IntPtr.Zero
-            Try
-                url = CreateFileUrl(path)
-                If url = IntPtr.Zero Then Return (0, 0)
-                source = CGImageSourceCreateWithURL(url, IntPtr.Zero)
-                If source = IntPtr.Zero Then Return (0, 0)
-                properties = CGImageSourceCopyPropertiesAtIndex(source, UIntPtr.Zero, IntPtr.Zero)
-                If properties = IntPtr.Zero Then Return (0, 0)
-
-                Dim width = ReadDictionaryInteger(
-                    properties, ReadFrameworkConstant(ImageIoHandle, "kCGImagePropertyPixelWidth"))
-                Dim height = ReadDictionaryInteger(
-                    properties, ReadFrameworkConstant(ImageIoHandle, "kCGImagePropertyPixelHeight"))
-                Dim orientation = ReadDictionaryInteger(
-                    properties, ReadFrameworkConstant(ImageIoHandle, "kCGImagePropertyOrientation"))
-                If orientation >= 5 AndAlso orientation <= 8 Then
-                    Dim swap = width
-                    width = height
-                    height = swap
-                End If
-                Return (width, height)
-            Catch
-                Return (0, 0)
-            Finally
-                Release(properties)
-                Release(source)
-                Release(url)
-            End Try
-        End Function
-
-        Private Shared Function ExtractWithMacImageIo(path As String) As MemoryStream
-            Dim url As IntPtr = IntPtr.Zero
-            Dim source As IntPtr = IntPtr.Zero
-            Dim options As IntPtr = IntPtr.Zero
-            Dim maxPixelNumber As IntPtr = IntPtr.Zero
-            Dim image As IntPtr = IntPtr.Zero
-            Dim data As IntPtr = IntPtr.Zero
-            Dim pngType As IntPtr = IntPtr.Zero
-            Dim destination As IntPtr = IntPtr.Zero
-
-            Try
-                url = CreateFileUrl(path)
-                If url = IntPtr.Zero Then Return Nothing
-                source = CGImageSourceCreateWithURL(url, IntPtr.Zero)
-                If source = IntPtr.Zero Then Return Nothing
-
-                Dim maximum = Integer.MaxValue
-                maxPixelNumber = CFNumberCreate(IntPtr.Zero, CFNumberSInt32Type, maximum)
-                If maxPixelNumber = IntPtr.Zero Then Return Nothing
-
-                Dim keys = {
-                    ReadFrameworkConstant(ImageIoHandle, "kCGImageSourceCreateThumbnailFromImageAlways"),
-                    ReadFrameworkConstant(ImageIoHandle, "kCGImageSourceCreateThumbnailWithTransform"),
-                    ReadFrameworkConstant(ImageIoHandle, "kCGImageSourceThumbnailMaxPixelSize")
-                }
-                Dim values = {
-                    ReadFrameworkConstant(CoreFoundationHandle, "kCFBooleanTrue"),
-                    ReadFrameworkConstant(CoreFoundationHandle, "kCFBooleanTrue"),
-                    maxPixelNumber
-                }
-                If keys.Any(Function(value) value = IntPtr.Zero) OrElse
-                   values.Any(Function(value) value = IntPtr.Zero) Then Return Nothing
-
-                options = CFDictionaryCreate(
-                    IntPtr.Zero, keys, values, CType(keys.Length, UIntPtr), IntPtr.Zero, IntPtr.Zero)
-                If options = IntPtr.Zero Then Return Nothing
-                image = CGImageSourceCreateThumbnailAtIndex(source, UIntPtr.Zero, options)
-                If image = IntPtr.Zero Then Return Nothing
-
-                data = CFDataCreateMutable(IntPtr.Zero, UIntPtr.Zero)
-                pngType = CFStringCreateWithCString(IntPtr.Zero, "public.png", CFStringEncodingUtf8)
-                If data = IntPtr.Zero OrElse pngType = IntPtr.Zero Then Return Nothing
-                destination = CGImageDestinationCreateWithData(data, pngType, CType(1, UIntPtr), IntPtr.Zero)
-                If destination = IntPtr.Zero Then Return Nothing
-
-                CGImageDestinationAddImage(destination, image, IntPtr.Zero)
-                If CGImageDestinationFinalize(destination) = 0 Then Return Nothing
-
-                Dim length = CFDataGetLength(data)
-                Dim bytesPointer = CFDataGetBytePtr(data)
-                If length <= 0 OrElse bytesPointer = IntPtr.Zero OrElse length > Integer.MaxValue Then Return Nothing
-
-                Dim bytes(CInt(length) - 1) As Byte
-                Marshal.Copy(bytesPointer, bytes, 0, bytes.Length)
-                Return New MemoryStream(bytes, writable:=False)
-            Catch
-                Return Nothing
-            Finally
-                Release(destination)
-                Release(pngType)
-                Release(data)
-                Release(image)
-                Release(options)
-                Release(maxPixelNumber)
-                Release(source)
-                Release(url)
-            End Try
-        End Function
-
-        Private Shared Function CreateFileUrl(path As String) As IntPtr
-            Dim pathBytes = Text.Encoding.UTF8.GetBytes(path)
-            Return CFURLCreateFromFileSystemRepresentation(
-                IntPtr.Zero, pathBytes, CType(pathBytes.Length, UIntPtr), False)
-        End Function
-
-        Private Shared Function ReadDictionaryInteger(dictionary As IntPtr, key As IntPtr) As Integer
-            If dictionary = IntPtr.Zero OrElse key = IntPtr.Zero Then Return 0
-            Dim number = CFDictionaryGetValue(dictionary, key)
-            If number = IntPtr.Zero Then Return 0
-            Dim value As Integer
-            Return If(CFNumberGetValue(number, CFNumberSInt32Type, value) <> 0, value, 0)
-        End Function
-
-        Private Shared Function ReadFrameworkConstant(handle As IntPtr, name As String) As IntPtr
-            If handle = IntPtr.Zero Then Return IntPtr.Zero
-            Dim symbol As IntPtr
-            If Not NativeLibrary.TryGetExport(handle, name, symbol) Then Return IntPtr.Zero
-            Return Marshal.ReadIntPtr(symbol)
-        End Function
-
-        Private Shared Function LoadFrameworkIfAvailable(path As String) As IntPtr
-            If Not OperatingSystem.IsMacOS() Then Return IntPtr.Zero
-            Try
-                Return NativeLibrary.Load(path)
-            Catch
-                Return IntPtr.Zero
-            End Try
-        End Function
-
-        Private Shared Sub Release(value As IntPtr)
-            If value <> IntPtr.Zero Then CFRelease(value)
-        End Sub
-
         Private Shared Function StringToUtf8(value As String) As IntPtr
             Dim bytes = Text.Encoding.UTF8.GetBytes(value)
             Dim ptr = Marshal.AllocCoTaskMem(bytes.Length + 1)
             Marshal.Copy(bytes, 0, ptr, bytes.Length)
             Marshal.WriteByte(ptr, bytes.Length, 0)
             Return ptr
-        End Function
-
-        Private Const CoreFoundationFramework As String =
-            "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
-        Private Const ImageIoFramework As String =
-            "/System/Library/Frameworks/ImageIO.framework/ImageIO"
-        Private Shared ReadOnly CoreFoundationHandle As IntPtr =
-            LoadFrameworkIfAvailable(CoreFoundationFramework)
-        Private Shared ReadOnly ImageIoHandle As IntPtr =
-            LoadFrameworkIfAvailable(ImageIoFramework)
-        Private Const CFNumberSInt32Type As Integer = 3
-        Private Const CFStringEncodingUtf8 As UInteger = &H8000100UI
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CFURLCreateFromFileSystemRepresentation(
-            allocator As IntPtr,
-            buffer As Byte(),
-            bufferLength As UIntPtr,
-            <MarshalAs(UnmanagedType.I1)> isDirectory As Boolean) As IntPtr
-        End Function
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CFNumberCreate(
-            allocator As IntPtr,
-            numberType As Integer,
-            ByRef value As Integer) As IntPtr
-        End Function
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CFDictionaryCreate(
-            allocator As IntPtr,
-            keys As IntPtr(),
-            values As IntPtr(),
-            count As UIntPtr,
-            keyCallbacks As IntPtr,
-            valueCallbacks As IntPtr) As IntPtr
-        End Function
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CFDictionaryGetValue(dictionary As IntPtr, key As IntPtr) As IntPtr
-        End Function
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CFNumberGetValue(
-            number As IntPtr,
-            numberType As Integer,
-            ByRef value As Integer) As Integer
-        End Function
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CFDataCreateMutable(
-            allocator As IntPtr,
-            capacity As UIntPtr) As IntPtr
-        End Function
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CFStringCreateWithCString(
-            allocator As IntPtr,
-            value As String,
-            encoding As UInteger) As IntPtr
-        End Function
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CFDataGetLength(data As IntPtr) As Long
-        End Function
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CFDataGetBytePtr(data As IntPtr) As IntPtr
-        End Function
-
-        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Sub CFRelease(value As IntPtr)
-        End Sub
-
-        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CGImageSourceCreateWithURL(url As IntPtr, options As IntPtr) As IntPtr
-        End Function
-
-        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CGImageSourceCopyPropertiesAtIndex(
-            source As IntPtr,
-            index As UIntPtr,
-            options As IntPtr) As IntPtr
-        End Function
-
-        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CGImageSourceCreateThumbnailAtIndex(
-            source As IntPtr,
-            index As UIntPtr,
-            options As IntPtr) As IntPtr
-        End Function
-
-        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CGImageDestinationCreateWithData(
-            data As IntPtr,
-            type As IntPtr,
-            count As UIntPtr,
-            options As IntPtr) As IntPtr
-        End Function
-
-        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Sub CGImageDestinationAddImage(
-            destination As IntPtr,
-            image As IntPtr,
-            properties As IntPtr)
-        End Sub
-
-        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
-        Private Shared Function CGImageDestinationFinalize(destination As IntPtr) As Integer
         End Function
 
     End Class

--- a/Services/ImageOrientationService.vb
+++ b/Services/ImageOrientationService.vb
@@ -377,6 +377,11 @@ Namespace Services
                     Return LoadOrientedAvaloniaBitmap(stream, psdRotation)
                 End Using
             End If
+            If HeifDecodeService.IsSupportedHeif(filePath) Then
+                Using stream = HeifDecodeService.ExtractPreview(filePath)
+                    Return If(stream IsNot Nothing, New Bitmap(stream), Nothing)
+                End Using
+            End If
             Return LoadOrientedAvaloniaBitmap(filePath)
         End Function
 

--- a/Services/ImageOrientationService.vb
+++ b/Services/ImageOrientationService.vb
@@ -335,8 +335,8 @@ Namespace Services
 
         ''' Wie LoadOrientedAvaloniaBitmap(filePath), erkennt aber Formate, die SkiaSharp nicht
         ''' selbst dekodiert, und reicht stattdessen deren aufbereiteten Strom herein: RAW über
-        ''' RawPreviewService.ExtractPreviewWithFallback, PSD/PSB über PsdPreviewService.
-        ''' Liefert Nothing, wenn daraus nichts zu holen war.
+        ''' RawPreviewService.ExtractPreviewWithFallback, PSD/PSB über PsdPreviewService,
+        ''' HEIC/HEIF/AVIF über HeifDecodeService. Liefert Nothing, wenn daraus nichts zu holen war.
         '''
         ''' Zur Einordnung der drei RAW-Wege - sie sind bewusst verschieden:
         '''   * ANZEIGE (hier): schnelle eingebettete Vorschau; findet der Scanner nichts, stößt
@@ -378,6 +378,12 @@ Namespace Services
                 End Using
             End If
             If HeifDecodeService.IsSupportedHeif(filePath) Then
+                ' Ohne diesen Zweig landete HEIC/AVIF beim Skia-Rueckfall unten, der das Format
+                ' nicht kann - im Filmstreifen und im Editor blieb die Flaeche deshalb leer,
+                ' obwohl Miniaturen und Renderpipeline HEIF laengst lesen konnten.
+                ' Kein LoadOrientedAvaloniaBitmap: der Dekoder legt die Drehung aus dem Container
+                ' schon auf. Und kein applySidecarRotation, weil HEIF kein Sidecar-Format ist
+                ' (RawSidecarService.IsSidecarFormat kennt nur RAW und PSD).
                 Using stream = HeifDecodeService.ExtractPreview(filePath)
                     Return If(stream IsNot Nothing, New Bitmap(stream), Nothing)
                 End Using

--- a/Services/MacImageIoService.vb
+++ b/Services/MacImageIoService.vb
@@ -1,0 +1,329 @@
+Imports System
+Imports System.IO
+Imports System.Runtime.InteropServices
+
+Namespace Services
+
+    ''' <summary>
+    ''' HEIC/HEIF/AVIF über die Bordmittel von macOS. ImageIO liest diese Formate dort seit jeher,
+    ''' weil das Betriebssystem den HEVC-Dekoder selbst mitbringt - auf einem Mac ist HEIC das
+    ''' Standardformat der Kamera, ein zusätzlich installiertes libheif wäre dort die Ausnahme.
+    '''
+    ''' Diese Datei ist bewusst die EINZIGE Stelle mit Apple-Interop. HeifDecodeService fragt nur
+    ''' IsAvailable und bekommt sonst dieselben Rückgaben wie vom libheif-Weg; es kennt weder
+    ''' CoreFoundation noch ImageIO und muss auch nicht wissen, auf welchem System es läuft.
+    '''
+    ''' Auf Linux und Windows wird nichts geladen: die beiden Handles bleiben leer, IsAvailable
+    ''' meldet False, und keine der DllImport-Deklarationen unten wird je angefasst. Für diese
+    ''' Systeme ändert die Datei damit nichts, der libheif-Weg bleibt dort der einzige.
+    '''
+    ''' An der Linie des Projekts ändert das nichts: ImageIO gehört zum Betriebssystem, FerrumPix
+    ''' liefert weiterhin keinen HEVC-Dekoder aus (siehe Klassenkommentar von HeifDecodeService).
+    ''' </summary>
+    Public NotInheritable Class MacImageIoService
+
+        Private Sub New()
+        End Sub
+
+        ''' <summary>Name für die Diagnose und für Feldberichte.</summary>
+        Public Const DecoderName As String = "ImageIO"
+
+        ''' <summary>True nur auf macOS und nur, wenn beide Frameworks geladen werden konnten.
+        ''' Sonst False - der Aufrufer nimmt dann seinen anderen Weg.</summary>
+        Public Shared ReadOnly Property IsAvailable As Boolean
+            Get
+                Return _coreFoundation <> IntPtr.Zero AndAlso _imageIo <> IntPtr.Zero
+            End Get
+        End Property
+
+        ''' <summary>Die Datei als PNG-Strom, in voller Auflösung und bereits gedreht - dieselbe
+        ''' Form, die HeifDecodeService.ExtractPreview auch vom libheif-Weg liefert.
+        '''
+        ''' Die Drehung aus dem Container legt ImageIO selbst auf
+        ''' (kCGImageSourceCreateThumbnailWithTransform), genau wie libheif es mit seinen
+        ''' Standard-Dekodieroptionen tut. Der Aufrufer darf also KEINE zweite Orientierungs-
+        ''' korrektur draufsetzen.
+        '''
+        ''' "Thumbnail" ist hier nur der Name der Programmierschnittstelle: ohne den Schlüssel
+        ''' kCGImageSourceThumbnailMaxPixelSize liefert ImageIO das Bild in voller Grösse, und
+        ''' kCGImageSourceCreateThumbnailFromImageAlways sorgt dafür, dass es das Hauptbild
+        ''' aufbereitet statt die kleine Vorschau aus dem Container zu nehmen.</summary>
+        Public Shared Function TryExtractPng(path As String) As MemoryStream
+            If Not IsAvailable OrElse String.IsNullOrWhiteSpace(path) Then Return Nothing
+
+            Dim url As IntPtr = IntPtr.Zero
+            Dim source As IntPtr = IntPtr.Zero
+            Dim options As IntPtr = IntPtr.Zero
+            Dim image As IntPtr = IntPtr.Zero
+            Dim data As IntPtr = IntPtr.Zero
+            Dim pngType As IntPtr = IntPtr.Zero
+            Dim destination As IntPtr = IntPtr.Zero
+
+            Try
+                url = CreateFileUrl(path)
+                If url = IntPtr.Zero Then Return Nothing
+                source = CGImageSourceCreateWithURL(url, IntPtr.Zero)
+                If source = IntPtr.Zero Then Return Nothing
+
+                Dim fromImageAlways = ReadConstant(_imageIo, "kCGImageSourceCreateThumbnailFromImageAlways")
+                Dim withTransform = ReadConstant(_imageIo, "kCGImageSourceCreateThumbnailWithTransform")
+                Dim booleanTrue = ReadConstant(_coreFoundation, "kCFBooleanTrue")
+                If fromImageAlways = IntPtr.Zero OrElse withTransform = IntPtr.Zero OrElse
+                   booleanTrue = IntPtr.Zero Then Return Nothing
+
+                Dim keys = {fromImageAlways, withTransform}
+                Dim values = {booleanTrue, booleanTrue}
+                options = CreateDictionary(keys, values)
+                If options = IntPtr.Zero Then Return Nothing
+
+                image = CGImageSourceCreateThumbnailAtIndex(source, UIntPtr.Zero, options)
+                If image = IntPtr.Zero Then Return Nothing
+
+                data = CFDataCreateMutable(IntPtr.Zero, UIntPtr.Zero)
+                pngType = CreateUtf8String("public.png")
+                If data = IntPtr.Zero OrElse pngType = IntPtr.Zero Then Return Nothing
+                destination = CGImageDestinationCreateWithData(data, pngType, New UIntPtr(1UI), IntPtr.Zero)
+                If destination = IntPtr.Zero Then Return Nothing
+
+                CGImageDestinationAddImage(destination, image, IntPtr.Zero)
+                If CGImageDestinationFinalize(destination) = 0 Then Return Nothing
+
+                Dim length = CFDataGetLength(data)
+                Dim bytesPointer = CFDataGetBytePtr(data)
+                If length <= 0 OrElse length > Integer.MaxValue OrElse bytesPointer = IntPtr.Zero Then Return Nothing
+
+                Dim bytes(CInt(length) - 1) As Byte
+                Marshal.Copy(bytesPointer, bytes, 0, bytes.Length)
+                Return New MemoryStream(bytes, writable:=False)
+            Catch ex As Exception
+                ' Ohne Log wäre auf einem fremden Mac nicht zu unterscheiden, ob die Datei defekt
+                ' ist oder ein Symbol des Systems fehlt.
+                DiagnosticLogService.LogException("MacImageIo.ExtractPng", ex)
+                Return Nothing
+            Finally
+                Release(destination)
+                Release(pngType)
+                Release(data)
+                Release(image)
+                Release(options)
+                Release(source)
+                Release(url)
+            End Try
+        End Function
+
+        ''' <summary>Maße ohne vollständiges Dekodieren - die Kopfdaten reichen dafür.
+        ''' Bei den Orientierungen 5 bis 8 steht das Bild quer, dann sind Breite und Höhe zu
+        ''' tauschen: TryExtractPng liefert die gedrehten Pixel, und beide Wege müssen dasselbe
+        ''' Format melden.</summary>
+        Public Shared Function TryGetSize(path As String) As (Width As Integer, Height As Integer)
+            If Not IsAvailable OrElse String.IsNullOrWhiteSpace(path) Then Return (0, 0)
+
+            Dim url As IntPtr = IntPtr.Zero
+            Dim source As IntPtr = IntPtr.Zero
+            Dim properties As IntPtr = IntPtr.Zero
+            Try
+                url = CreateFileUrl(path)
+                If url = IntPtr.Zero Then Return (0, 0)
+                source = CGImageSourceCreateWithURL(url, IntPtr.Zero)
+                If source = IntPtr.Zero Then Return (0, 0)
+                properties = CGImageSourceCopyPropertiesAtIndex(source, UIntPtr.Zero, IntPtr.Zero)
+                If properties = IntPtr.Zero Then Return (0, 0)
+
+                Dim width = ReadDictionaryInteger(properties, ReadConstant(_imageIo, "kCGImagePropertyPixelWidth"))
+                Dim height = ReadDictionaryInteger(properties, ReadConstant(_imageIo, "kCGImagePropertyPixelHeight"))
+                Dim orientation = ReadDictionaryInteger(properties, ReadConstant(_imageIo, "kCGImagePropertyOrientation"))
+                If orientation >= 5 AndAlso orientation <= 8 Then
+                    Dim swap = width
+                    width = height
+                    height = swap
+                End If
+                Return (width, height)
+            Catch ex As Exception
+                DiagnosticLogService.LogException("MacImageIo.GetSize", ex)
+                Return (0, 0)
+            Finally
+                Release(properties)
+                Release(source)
+                Release(url)
+            End Try
+        End Function
+
+        ' ── CoreFoundation-Handgriffe ────────────────────────────────────────────
+
+        Private Shared Function CreateFileUrl(path As String) As IntPtr
+            Dim pathBytes = Text.Encoding.UTF8.GetBytes(path)
+            Return CFURLCreateFromFileSystemRepresentation(
+                IntPtr.Zero, pathBytes, New UIntPtr(CUInt(pathBytes.Length)), False)
+        End Function
+
+        Private Shared Function CreateUtf8String(value As String) As IntPtr
+            ' Die Bytes selbst erzeugen statt die Zeichenkette marshallen zu lassen: so steht die
+            ' Kodierung im Code und hängt nicht am CharSet-Standard der Laufzeit.
+            Dim bytes = Text.Encoding.UTF8.GetBytes(value & vbNullChar)
+            Return CFStringCreateWithCString(IntPtr.Zero, bytes, CFStringEncodingUtf8)
+        End Function
+
+        ''' <summary>Ein Optionswörterbuch mit den Standard-Rückrufen für CoreFoundation-Typen.
+        ''' Die sind wichtig: ohne sie behielte das Wörterbuch weder Schlüssel noch Werte am Leben
+        ''' und vergliche Schlüssel über die Zeigeradresse statt über CFEqual.</summary>
+        Private Shared Function CreateDictionary(keys As IntPtr(), values As IntPtr()) As IntPtr
+            ' kCFTypeDictionaryKeyCallBacks ist eine Struktur, keine Referenz - hier zählt die
+            ' ADRESSE des Symbols, nicht der Inhalt an dieser Adresse.
+            Dim keyCallbacks = ReadSymbolAddress(_coreFoundation, "kCFTypeDictionaryKeyCallBacks")
+            Dim valueCallbacks = ReadSymbolAddress(_coreFoundation, "kCFTypeDictionaryValueCallBacks")
+            If keyCallbacks = IntPtr.Zero OrElse valueCallbacks = IntPtr.Zero Then Return IntPtr.Zero
+            Return CFDictionaryCreate(
+                IntPtr.Zero, keys, values, New UIntPtr(CUInt(keys.Length)), keyCallbacks, valueCallbacks)
+        End Function
+
+        Private Shared Function ReadDictionaryInteger(dictionary As IntPtr, key As IntPtr) As Integer
+            If dictionary = IntPtr.Zero OrElse key = IntPtr.Zero Then Return 0
+            Dim number = CFDictionaryGetValue(dictionary, key)
+            If number = IntPtr.Zero Then Return 0
+            Dim value As Integer
+            Return If(CFNumberGetValue(number, CFNumberSInt32Type, value) <> 0, value, 0)
+        End Function
+
+        ''' <summary>Adresse eines exportierten Symbols.</summary>
+        Private Shared Function ReadSymbolAddress(handle As IntPtr, name As String) As IntPtr
+            If handle = IntPtr.Zero Then Return IntPtr.Zero
+            Dim symbol As IntPtr
+            If Not NativeLibrary.TryGetExport(handle, name, symbol) Then Return IntPtr.Zero
+            Return symbol
+        End Function
+
+        ''' <summary>Wert einer exportierten Zeigerkonstante (etwa eines kCG...-Schlüssels).</summary>
+        Private Shared Function ReadConstant(handle As IntPtr, name As String) As IntPtr
+            Dim symbol = ReadSymbolAddress(handle, name)
+            If symbol = IntPtr.Zero Then Return IntPtr.Zero
+            Return Marshal.ReadIntPtr(symbol)
+        End Function
+
+        Private Shared Sub Release(value As IntPtr)
+            If value <> IntPtr.Zero Then CFRelease(value)
+        End Sub
+
+        Private Shared Function LoadFrameworkIfAvailable(path As String) As IntPtr
+            If Not OperatingSystem.IsMacOS() Then Return IntPtr.Zero
+            Try
+                Return NativeLibrary.Load(path)
+            Catch
+                ' Kein Log: auf einem System ohne diese Frameworks ist das der Normalfall, nicht
+                ' ein Fehler. Der Aufrufer sieht es an IsAvailable.
+                Return IntPtr.Zero
+            End Try
+        End Function
+
+        ' ── Native Bindung ───────────────────────────────────────────────────────
+
+        Private Const CoreFoundationFramework As String =
+            "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+        Private Const ImageIoFramework As String =
+            "/System/Library/Frameworks/ImageIO.framework/ImageIO"
+
+        ' Die Handles dienen nur dazu, die exportierten Konstanten auszulesen - die Funktionen
+        ' darunter laufen über DllImport. Beide Wege öffnen dieselbe Bibliothek, das ist harmlos
+        ' (dlopen zählt mit), und die Handles bleiben absichtlich bis zum Programmende offen.
+        Private Shared ReadOnly _coreFoundation As IntPtr =
+            LoadFrameworkIfAvailable(CoreFoundationFramework)
+        Private Shared ReadOnly _imageIo As IntPtr =
+            LoadFrameworkIfAvailable(ImageIoFramework)
+
+        ' kCFNumberSInt32Type = 3; kCFStringEncodingUTF8 = 0x08000100.
+        Private Const CFNumberSInt32Type As Integer = 3
+        Private Const CFStringEncodingUtf8 As UInteger = &H8000100UI
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFURLCreateFromFileSystemRepresentation(
+            allocator As IntPtr,
+            buffer As Byte(),
+            bufferLength As UIntPtr,
+            <MarshalAs(UnmanagedType.I1)> isDirectory As Boolean) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDictionaryCreate(
+            allocator As IntPtr,
+            keys As IntPtr(),
+            values As IntPtr(),
+            count As UIntPtr,
+            keyCallbacks As IntPtr,
+            valueCallbacks As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDictionaryGetValue(dictionary As IntPtr, key As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFNumberGetValue(
+            number As IntPtr,
+            numberType As Integer,
+            ByRef value As Integer) As Integer
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDataCreateMutable(
+            allocator As IntPtr,
+            capacity As UIntPtr) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFStringCreateWithCString(
+            allocator As IntPtr,
+            value As Byte(),
+            encoding As UInteger) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDataGetLength(data As IntPtr) As Long
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CFDataGetBytePtr(data As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(CoreFoundationFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Sub CFRelease(value As IntPtr)
+        End Sub
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageSourceCreateWithURL(url As IntPtr, options As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageSourceCopyPropertiesAtIndex(
+            source As IntPtr,
+            index As UIntPtr,
+            options As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageSourceCreateThumbnailAtIndex(
+            source As IntPtr,
+            index As UIntPtr,
+            options As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageDestinationCreateWithData(
+            data As IntPtr,
+            type As IntPtr,
+            count As UIntPtr,
+            options As IntPtr) As IntPtr
+        End Function
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Sub CGImageDestinationAddImage(
+            destination As IntPtr,
+            image As IntPtr,
+            properties As IntPtr)
+        End Sub
+
+        <DllImport(ImageIoFramework, CallingConvention:=CallingConvention.Cdecl)>
+        Private Shared Function CGImageDestinationFinalize(destination As IntPtr) As Integer
+        End Function
+
+    End Class
+
+End Namespace

--- a/ViewModels/ViewerViewModel.vb
+++ b/ViewModels/ViewerViewModel.vb
@@ -1913,6 +1913,10 @@ Namespace ViewModels
                 End Using
             End If
             If HeifDecodeService.IsSupportedHeif(path) Then
+                ' HEIF fehlte hier bisher ganz: der Viewer fiel unten auf Skia zurueck, das HEIC
+                ' und AVIF nicht dekodiert. IsRenderableImagePath fuehrt die Formate laengst, und
+                ' Miniaturen wie Renderpipeline konnten sie auch - nur das grosse Bild blieb leer.
+                ' Der Dekoder liefert bereits gedreht, deshalb keine Orientierungskorrektur.
                 Using preview = HeifDecodeService.ExtractPreview(path)
                     Return If(preview IsNot Nothing, New Bitmap(preview), Nothing)
                 End Using

--- a/ViewModels/ViewerViewModel.vb
+++ b/ViewModels/ViewerViewModel.vb
@@ -1912,6 +1912,11 @@ Namespace ViewModels
                               Nothing)
                 End Using
             End If
+            If HeifDecodeService.IsSupportedHeif(path) Then
+                Using preview = HeifDecodeService.ExtractPreview(path)
+                    Return If(preview IsNot Nothing, New Bitmap(preview), Nothing)
+                End Using
+            End If
             If FpxService.IsFpx(path) Then
                 Using preview = FpxService.ExtractComposite(path)
                     Return If(preview IsNot Nothing, New Bitmap(preview), Nothing)

--- a/Views/GalleryView.axaml.vb
+++ b/Views/GalleryView.axaml.vb
@@ -1290,9 +1290,16 @@ Namespace Views
             overlay.IsVisible = True
             Me.Focus()
             Try
-                ' Auto-Variante: erkennt Buendel (Komposit), RAW und PSD - derselbe Weg wie die
-                ' Filmstrip-Vorschau.
-                Dim bmp = Await Task.Run(Function() ImageOrientationService.LoadOrientedAvaloniaBitmapAuto(item.FilePath))
+                Dim bmp = Await Task.Run(Function() As Bitmap
+                                             If RawPreviewService.IsSupportedRaw(item.FilePath) Then
+                                                 Using preview = RawPreviewService.ExtractPreviewWithFallback(item.FilePath)
+                                                     Return If(preview IsNot Nothing, ImageOrientationService.LoadOrientedAvaloniaBitmap(preview), Nothing)
+                                                 End Using
+                                             End If
+                                             ' Die Auto-Variante behandelt FPX, HEIF/AVIF, PSD und die
+                                             ' uebrigen Formate ueber denselben orientierten Ladeweg.
+                                             Return ImageOrientationService.LoadOrientedAvaloniaBitmapAuto(item.FilePath)
+                                         End Function)
                 If overlay.IsVisible AndAlso bmp IsNot Nothing Then img.Source = bmp
             Catch
             End Try


### PR DESCRIPTION
## Summary

Use the native macOS ImageIO frameworks to decode HEIC, HEIF, and supported AVIF images, and route the gallery, viewer, and editor display paths through the existing HEIF decoding service.

Windows and Linux retain the existing optional system `libheif` implementation. No codec library is bundled, and HEIF support remains read-only.

## Background

FerrumPix already recognizes HEIC, HEIF, and AVIF files and includes an optional decoder based on a system-provided `libheif`. On macOS, however, the application did not use the HEIF decoding support built into ImageIO.

A standard macOS installation does not provide `libheif`, so HEIF decoding required an additional compatible library to be installed and discoverable by the application. When that library was unavailable, FerrumPix fell back to the generic SkiaSharp/Avalonia bitmap path, which cannot decode HEIC, leaving the image unopened even though macOS itself supports the format.

The decoding paths were also inconsistent. Thumbnail generation and the editor rendering pipeline could use `HeifDecodeService`, while the viewer, editor display path, and gallery quick preview could still pass HEIF files directly to the unsupported generic decoder. Installing `libheif` therefore did not guarantee consistent behavior across all views.

## Changes

- Use Core Foundation and ImageIO for native HEIF decoding on macOS.
- Read image dimensions and orientation through ImageIO metadata.
- Convert the decoded image to a PNG stream for the existing Avalonia and SkiaSharp pipelines.
- Route the viewer and editor display paths through `HeifDecodeService`.
- Route the gallery quick preview through the format-aware image loader.
- Keep the existing dynamically loaded system `libheif` implementation on Windows and Linux.
- Keep HEIF decoding read-only; edited images must still be saved as FPX or exported to an encodable format.
- Update the service documentation in English to describe the ImageIO/libheif backend split while preserving the system-library, distribution, orientation, and read-only design rationale.

## Dependency and distribution scope

This change does not bundle `libheif`, an HEVC decoder, or any other native codec dependency. It uses the decoder already provided by macOS and preserves the project's existing optional system-library policy on other platforms.

It does not add HEIF encoding or in-place HEIF saving.

## Testing

Tested on a Mac mini with Apple M4:

- Published and launched the macOS ARM64 application bundle.
- Confirmed that HEIC gallery thumbnails render.
- Confirmed that HEIC images open and render in the viewer.
- Confirmed that HEIC images open in the editor and reach the ready state at the expected dimensions and orientation.
- Confirmed that leaving the editor without saving returns to the gallery normally.
- Rebased onto upstream 0.9.17 and completed a macOS ARM64 Release build successfully.

Edited-image saving was not retested because this change only replaces the source decoding path and does not modify the existing save or encoding pipeline.

The functional HEIC checks above were performed before the rebase. The rebased branch was build-verified but was not functionally retested.

Windows and Linux were not tested in this round.
